### PR TITLE
Improve design: compact UI, summary redesign, tooltip fixes (from 52-improve-design)

### DIFF
--- a/src/components/MultiStepForm.tsx
+++ b/src/components/MultiStepForm.tsx
@@ -375,7 +375,7 @@ const MultiStepFormContent: React.FC = () => {
     <div className="flex flex-row  animate-fade-in-right duration-1000 lg:w-[30%] xs:w-[100%] mx-auto">
       {/* <Sidebar activeMenuItem={activeMenuItem} setActiveMenuItem={setActiveMenuItem} /> */}
 
-      <main className="w-full h-full flex flex-col bg-white p-6 relative overflow-hidden">
+      <main className="w-full h-full flex flex-col bg-white p-6 relative overflow-x-clip">
         <div className="flex justify-center items-center gap-4">
           <img src={logo} alt="Logo" className="w-48 " />
           {ticketingPartnerLogo && (

--- a/src/components/customComponents/FileUploadField.tsx
+++ b/src/components/customComponents/FileUploadField.tsx
@@ -384,21 +384,21 @@ const FileUploadField: React.FC<FileUploadFieldProps> = ({
     }
   };
 
-  const formatFileSize = (bytes: number): string => {
+ /*  const formatFileSize = (bytes: number): string => {
     if (!bytes || bytes === 0 || isNaN(bytes)) return '0 Bytes';
     const k = 1024;
     const sizes = ['Bytes', 'KB', 'MB', 'GB'];
     const i = Math.floor(Math.log(bytes) / Math.log(k));
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
-  };
+  }; */
 
   return (  
-    <div className={`flex flex-col w-full mb-16 ${className}`}>
-      <h4 className=" text-md font-medium text-neutral-900 leading-tight ">{title}</h4>
-      {description && <p className=" text-xs font-300 text-gray-500" dangerouslySetInnerHTML={{ __html: description }} />}
+    <div className={`flex flex-col w-full mb-6 ${className}`}>
+      <h4 className="text-xs font-semibold text-neutral-700 leading-tight">{title}</h4>
+      {description && <p className="text-[10px] font-300 text-gray-400 leading-tight" dangerouslySetInnerHTML={{ __html: description }} />}
       
       <div
-        className={`relative border-2 border-dashed rounded-lg p-6 mt-4 text-center transition-colors ${
+        className={`relative border-2 border-dashed rounded-lg px-4 py-3 mt-2 text-center transition-colors ${
           isProcessing
             ? 'border-blue-500 bg-blue-50 cursor-wait'
             : dragActive 
@@ -419,48 +419,29 @@ const FileUploadField: React.FC<FileUploadFieldProps> = ({
           className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
           id={`file-upload-${field}`}
           disabled={isProcessing}
+          title=""
         />
         
         {isProcessing ? (
-          <div className="flex flex-col items-center justify-center space-y-2">
-            <svg className="w-8 h-8 text-blue-500 animate-spin" fill="none" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          <div className="flex items-center justify-center gap-2 py-1">
+            <svg className="w-4 h-4 text-blue-500 animate-spin flex-shrink-0" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
             </svg>
-            <div className="text-sm text-blue-600 font-medium">
-              Processing and uploading files...
-            </div>
-            <p className="text-xs text-gray-500">
-              Please wait
-            </p>
+            <span className="text-sm text-blue-600 font-medium">Uploading... please wait</span>
           </div>
         ) : (
-          <div className="flex flex-col items-center justify-center space-y-2">
-            <svg 
-              className="w-8 h-8 text-gray-400" 
-              fill="none" 
-              stroke="currentColor" 
-              viewBox="0 0 24 24"
-            >
-              <path 
-                strokeLinecap="round" 
-                strokeLinejoin="round" 
-                strokeWidth={2} 
-                d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" 
-              />
+          <div className="flex items-center justify-center gap-3 py-1">
+            <svg className="w-5 h-5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
             </svg>
-            
             <div className="text-sm text-gray-600">
-              <span className="font-medium text-blue-600 hover:text-blue-500">
-                Click to select
+              <span className="font-medium text-orange-500 hover:text-rose-500 transition-colors">Click to select</span>
+              {' '}or drag & drop
+              <span className="text-xs text-gray-400 ml-2">
+                ({accept.split(',').map(ext => ext.trim()).join(', ')}{multiple && ', multiple'})
               </span>
-              {' '}or drag and drop your files here
             </div>
-            
-            <p className="text-xs text-gray-500">
-              {accept.split(',').map(ext => ext.trim()).join(', ')} accepted
-              {multiple && ' (multiple files accepted)'}
-            </p>
           </div>
         )}
       </div>
@@ -506,89 +487,55 @@ const FileUploadField: React.FC<FileUploadFieldProps> = ({
       
       {/* Zone d'affichage des fichiers sélectionnés */}
       {validFiles.length > 0 && (
-        <div className="mt-4 space-y-3">
-          <div className="flex items-center justify-between">
-            <h4 className="text-sm font-medium text-gray-700">
-              Selected files ({validFiles.length})
-            </h4>
+        <div className="mt-2">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-[10px] text-gray-400 uppercase tracking-wide font-medium">
+              {validFiles.length} file{validFiles.length > 1 ? 's' : ''} selected
+            </span>
             {validFiles.length > 1 && (
-              <button
-                onClick={handleClearAllFiles}
-                className="text-sm text-red-500 hover:text-red-700"
-              >
+              <button onClick={handleClearAllFiles} className="text-[10px] text-red-400 hover:text-red-600">
                 Remove all
               </button>
             )}
           </div>
-          
-          <div className="space-y-2 max-h-48 overflow-y-auto">
+          <div className="flex flex-wrap gap-1.5">
             {validFiles.map((file, index) => {
               const realIndex = files.findIndex(f => f === file);
               const uploadStatus = uploadStatuses[realIndex];
-              
+              const isError = uploadStatus?.status === 'error';
+              const isSuccess = uploadStatus?.status === 'success';
+              const isUploading = uploadStatus?.status === 'uploading';
+
               return (
-                <div 
+                <div
                   key={`${file.name}-${index}`}
-                  className={`flex items-center justify-between p-3 rounded-lg border ${
-                    uploadStatus?.status === 'error' 
-                      ? 'bg-red-50 border-red-300' 
-                      : uploadStatus?.status === 'success'
-                        ? 'bg-green-50 border-green-300'
-                        : 'bg-gray-50 border-gray-300'
+                  title={isError ? uploadStatus.error : file.name}
+                  className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium border max-w-[200px] ${
+                    isError
+                      ? 'bg-red-50 border-red-200 text-red-600'
+                      : isSuccess
+                        ? 'bg-green-50 border-green-200 text-green-700'
+                        : isUploading
+                          ? 'bg-blue-50 border-blue-200 text-blue-600'
+                          : 'bg-green-50 border-green-200 text-green-700'
                   }`}
                 >
-                  <div className="flex items-center space-x-3 flex-1 min-w-0">
-                    {/* Icône de statut */}
-                    {uploadStatus?.status === 'uploading' && (
-                      <svg className="w-5 h-5 text-blue-500 flex-shrink-0 animate-spin" fill="none" viewBox="0 0 24 24">
-                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                      </svg>
-                    )}
-                    {uploadStatus?.status === 'success' && (
-                      <svg className="w-5 h-5 text-green-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
-                    )}
-                    {uploadStatus?.status === 'error' && (
-                      <svg className="w-5 h-5 text-red-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
-                    )}
-                    {(!uploadStatus || uploadStatus.status === 'pending') && (
-                      <svg className="w-5 h-5 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                      </svg>
-                    )}
-                    
-                    <div className="flex-1 min-w-0">
-                      <p className={`text-sm font-medium truncate ${
-                        uploadStatus?.status === 'error' ? 'text-red-700' : 'text-gray-700'
-                      }`}>
-                        {file.name || 'Unknown file'}
-                      </p>
-                      <p className={`text-xs ${
-                        uploadStatus?.status === 'error' ? 'text-red-600' : 'text-gray-500'
-                      }`}>
-                        {formatFileSize(file.size)} • {file.type || 'Unknown type'}
-                        {uploadStatus?.status === 'uploading' && ' • Uploading...'}
-                        {uploadStatus?.status === 'success' && ' • ✓ Uploaded'}
-                      </p>
-                      {uploadStatus?.status === 'error' && (
-                        <p className="text-xs text-red-600 font-semibold mt-1">
-                          ⚠️ {uploadStatus.error}
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                  
+                  {isUploading && (
+                    <svg className="w-2.5 h-2.5 animate-spin flex-shrink-0" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                    </svg>
+                  )}
+                  {isSuccess && <span className="flex-shrink-0">✓</span>}
+                  {isError && <span className="flex-shrink-0">⚠</span>}
+                  <span className="truncate">{file.name || 'Unknown file'}</span>
                   <button
                     onClick={() => handleRemoveFile(index)}
-                    className="text-red-500 hover:text-red-700 p-1 ml-2 flex-shrink-0"
-                    title="Remove file"
+                    className="flex-shrink-0 ml-0.5 opacity-50 hover:opacity-100"
+                    title="Remove"
                   >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
                     </svg>
                   </button>
                 </div>

--- a/src/components/customComponents/StepTitle.tsx
+++ b/src/components/customComponents/StepTitle.tsx
@@ -4,10 +4,10 @@ const StepTitle = ({ title }: { title: string }) => {
     return (
         <div className="my-4 text-left">
             <h2 className="
-                text-base
-                font-semibold
+                text-lg
+                font-bold
                 tracking-wide
-                text-gray-600
+                text-gray-700
             ">
                 {title}
             </h2>

--- a/src/components/step3/Finances.tsx
+++ b/src/components/step3/Finances.tsx
@@ -295,9 +295,9 @@ const FinancesStep: React.FC = () => {
             <svg className="w-4 h-4 text-gray-400 hover:text-gray-600 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
-            <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 text-xs text-white bg-gray-800 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-10">
+            <div className="absolute bottom-full right-0 mb-2 px-3 py-2 text-xs text-white bg-gray-800 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none w-48 z-50">
               This includes a group of affiliates that share ownership
-              <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-800"></div>
+              <div className="absolute top-full right-2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-800"></div>
             </div>
           </div>
         </div>

--- a/src/components/step4/FinancialInformationStep.tsx
+++ b/src/components/step4/FinancialInformationStep.tsx
@@ -13,7 +13,7 @@ const FinancialInformationStep: React.FC = () => {
 
   return (
     <div className="flex flex-col w-full animate-fade-in-right duration-1000">
-      <StepTitle title="Finance" />
+      <StepTitle title="2. Finance" />
       
       <div className="w-full">  
         <FileUploadField

--- a/src/components/step4/LegalInformationStep.tsx
+++ b/src/components/step4/LegalInformationStep.tsx
@@ -12,7 +12,7 @@ const LegalInformationStep: React.FC = () => {
 
   return (
     <div className="flex flex-col w-full animate-fade-in-right duration-1000">
-      <StepTitle title="Contractual & Legal" />
+      <StepTitle title="3. Contractual & Legal" />
 
       <div className="w-full">  
         <FileUploadField

--- a/src/components/step4/TicketingInformationStep.tsx
+++ b/src/components/step4/TicketingInformationStep.tsx
@@ -13,7 +13,7 @@ const TicketingInformationStep: React.FC = () => {
 
   return (
     <div className="flex flex-col w-full animate-fade-in-right duration-1000">
-      <StepTitle title="Ticketing" />
+      <StepTitle title="1. Ticketing" />
       
       <div className="w-full">  
         <FileUploadField

--- a/src/components/step4/index.tsx
+++ b/src/components/step4/index.tsx
@@ -5,7 +5,7 @@ import LegalInformationStep from './LegalInformationStep';
 
 const Step4: React.FC = () => {
   return (
-    <div className="flex flex-col justify-center w-full pt-8 animate-fade-in-right duration-1000">
+    <div className="flex flex-col justify-center w-full  animate-fade-in-right duration-1000">
       <TicketingInformationStep />
       <FinancialInformationStep />
       <LegalInformationStep />

--- a/src/components/step5/SummaryStep.tsx
+++ b/src/components/step5/SummaryStep.tsx
@@ -8,13 +8,25 @@ interface SummaryStepProps {
   onStepClick?: (stepNumber: number) => void;
 }
 
+const PencilIcon = () => (
+  <svg className="absolute top-3 right-3 w-3.5 h-3.5 text-gray-400 hover:text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+  </svg>
+);
+
+const Row = ({ label, value }: { label: string; value?: string | number | null }) => (
+  <div className="flex justify-between gap-2">
+    <span className="text-gray-500 shrink-0">{label}:</span>
+    <span className="text-gray-600 font-semibold text-right">{value || '—'}</span>
+  </div>
+);
+
 const SummaryStep: React.FC<SummaryStepProps> = ({ renderValidationErrors, onStepClick }) => {
   const formData = useSelector((state: RootState) => state.form.formData);
   const diligenceInfo = useSelector((state: RootState) => state.form.diligenceInfo);
   
   const { personalInfo, companyInfo, ticketingInfo, volumeInfo, fundsInfo, ownershipInfo, financesInfo } = formData;
 
-  // Check if we're in development mode
   const [disableSubmissionBlock] = useState(() => {
     return localStorage.getItem('DISABLE_SUBMISSION_BLOCK') === 'true';
   });
@@ -23,423 +35,108 @@ const SummaryStep: React.FC<SummaryStepProps> = ({ renderValidationErrors, onSte
     localStorage.setItem('DISABLE_SUBMISSION_BLOCK', disableSubmissionBlock.toString());
   }, [disableSubmissionBlock]);
 
- 
+  const cardClass = "bg-white rounded-lg p-3 cursor-pointer hover:bg-gray-50 transition-colors duration-200 relative";
 
   return (
-    <div className="flex flex-col items-center justify-center w-full mt-16 animate-fade-in-right duration-1000">
-      
-     
-      {/* <p className="text-gray-500 w-[30%] mx-auto mb-8 text-center text-justify"><span className="font-bold text-neutral-800 text-md">Notes and Disclosures:</span> The information appearing in this form (the "Form") is confidential and is being delivered and requested to clients and prospective clients of SoundCheck Capital to assess their eligibility to SoundCheck's Capital Advance program. This Form is not to be reproduced or distributed and is intended solely for the use of the person to whom it has been delivered. Unauthorized reproduction or distribution of all or any of this material or the information contained herein is strictly prohibited. Each prospective client agrees to the foregoing.</p>
- */}
+    <div className="flex flex-col items-center justify-center w-full mt-4 animate-fade-in-right duration-1000">
       {renderValidationErrors}
 
-   
+      <div className="w-full max-w-2xl space-y-1 text-xs">
 
-       <div className="w-full max-w-2xl space-y-6">
-        {/* Personal Information */}
-        <div 
-          className="bg-white rounded-lg  p-6 cursor-pointer hover:bg-gray-50 transition-colors duration-200" 
-          onClick={() => onStepClick?.(1)}
-        >
-          <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
-            Personal Information
-            <span className="ml-2 text-xs text-blue-600 font-normal">(Click to edit)</span>
-          </h3>
-          <div className="grid grid-cols-1 gap-4 text-sm">
-            <div>
-              <span className=" text-gray-600 font-bold">Name:</span>
-              <span className="ml-2 text-gray-800">{personalInfo.firstname} {personalInfo.lastname}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Email:</span>
-              <span className="ml-2 text-gray-800">{personalInfo.email}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Phone:</span>
-              <span className="ml-2 text-gray-800">{personalInfo.phone}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Role:</span>
-              <span className="ml-2 text-gray-800">{personalInfo.role}</span>
-            </div>
+        {/* Step 1 — Business Info */}
+        <div className={cardClass} onClick={() => onStepClick?.(1)}>
+          <PencilIcon />
+          <h3 className="text-sm font-semibold text-gray-800 mb-2">Business Info</h3>
+          <div className="space-y-0.5">
+            <Row label="Name" value={`${personalInfo.firstname} ${personalInfo.lastname}`} />
+            <Row label="Email" value={personalInfo.email} />
+            <Row label="Phone" value={personalInfo.phone} />
+            <Row label="Role" value={personalInfo.role} />
+            <Row label="Company" value={companyInfo.name} />
+            <Row label="DBA" value={companyInfo.dba} />
+            <Row label="EIN" value={companyInfo.ein} />
+            <Row label="Legal Entity" value={companyInfo.businessType} />
+            <Row label="Years in Business" value={companyInfo.yearsInBusiness} />
+            <Row label="Address" value={companyInfo.companyAddressDisplay} />
+            <Row label="State of Incorporation" value={companyInfo.stateOfIncorporation} />
+            <Row label="Ticketing Partner" value={ticketingInfo.currentPartner} />
+            <Row label="Settlement From" value={ticketingInfo.paymentProcessing} />
+            <Row label="Settlement Policy" value={ticketingInfo.settlementPayout} />
+            <Row label="Events / Year" value={volumeInfo.nextYearEvents} />
+            <Row label="Gross Ticketing Volume" value={formatCurrency(volumeInfo.nextYearSales)} />
           </div>
         </div>
 
-        {/* Company Information */}
-        <div 
-          className="bg-white rounded-lg  p-6 cursor-pointer hover:bg-gray-50 transition-colors duration-200" 
-          onClick={() => onStepClick?.(2)}
-        >
-          <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
-            Company Information
-            <span className="ml-2 text-xs text-blue-600 font-normal">(Click to edit)</span>
-          </h3>
-          <div className="grid grid-cols-1 gap-4 text-sm">
-            <div>
-              <span className=" text-gray-600 font-bold">Company Name:</span>
-              <span className="ml-2 text-gray-800">{companyInfo.name}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">DBA:</span>
-              <span className="ml-2 text-gray-800">{companyInfo.dba}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Client Type:</span>
-              <span className="ml-2 text-gray-800">{companyInfo.clientType}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Legal Entity Type:</span>
-              <span className="ml-2 text-gray-800">{companyInfo.businessType}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Years in Business:</span>
-              <span className="ml-2 text-gray-800">{companyInfo.yearsInBusiness}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">EIN:</span>
-              <span className="ml-2 text-gray-800">{companyInfo.ein}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Address:</span>
-              <span className="ml-2 text-gray-800">{companyInfo.companyAddressDisplay}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">State of Incorporation:</span>
-              <span className="ml-2 text-gray-800">{companyInfo.stateOfIncorporation}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Socials:</span>
-              <span className="ml-2 text-gray-800">{companyInfo.socials}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Member Of:</span>
-              <span className="ml-2 text-gray-800">{companyInfo.memberOf}</span>
-            </div>
+        {/* Step 2 — Funding */}
+        <div className={cardClass} onClick={() => onStepClick?.(2)}>
+          <PencilIcon />
+          <h3 className="text-sm font-semibold text-gray-800 mb-2">Funding</h3>
+          <div className="space-y-0.5">
+            <Row label="Purchase Price" value={formatCurrency(parseFloat(fundsInfo.yourFunds) || 0)} />
+            <Row label="Timing of Funding" value={fundsInfo.timingOfFunding} />
+            <Row label="Use of Proceeds" value={fundsInfo.useOfProceeds} />
           </div>
         </div>
 
-        {/* Ticketing Information */}
-        <div 
-          className="bg-white rounded-lg  p-6 cursor-pointer hover:bg-gray-50 transition-colors duration-200" 
-          onClick={() => onStepClick?.(3)}
-        >
-          <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
-            Ticketing Information
-            <span className="ml-2 text-xs text-blue-600 font-normal">(Click to edit)</span>
-          </h3>
-          <div className="grid grid-cols-1 gap-4 text-sm">
-          <div>
-              <span className=" text-gray-600 font-bold">Settlement From:</span>
-              <span className="ml-2 text-gray-800">{ticketingInfo.paymentProcessing}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Ticketing Partner:</span>
-              <span className="ml-2 text-gray-800">{ticketingInfo.currentPartner}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Settlement Policy:</span>
-              <span className="ml-2 text-gray-800">{ticketingInfo.settlementPayout}</span>
-            </div>
-           
-            {ticketingInfo.otherPartner && (
-              <div>
-                <span className=" text-gray-600 font-bold">Other Partner:</span>
-                <span className="ml-2 text-gray-800">{ticketingInfo.otherPartner}</span>
+        {/* Step 3 — Business & Ownership */}
+        <div className={cardClass} onClick={() => onStepClick?.(3)}>
+          <PencilIcon />
+          <h3 className="text-sm font-semibold text-gray-800 mb-2">Business & Ownership</h3>
+          <div className="space-y-0.5">
+            {ownershipInfo.owners.map((owner, index) => (
+              <div key={owner.id} className="mb-1">
+                <p className="font-semibold text-gray-600 mb-0.5">Owner {index + 1}</p>
+                <Row label="Name" value={owner.ownerName} />
+                <Row label="Ownership" value={`${owner.ownershipPercentage}%`} />
+                <Row label="Address" value={owner.ownerAddress} />
+                <Row label="Birth Date" value={owner.ownerBirthDate} />
               </div>
-            )}
-            
-          </div>
-        </div>
-
-        {/* Volume Information */}
-        <div 
-          className="bg-white rounded-lg  p-6 cursor-pointer hover:bg-gray-50 transition-colors duration-200" 
-          onClick={() => onStepClick?.(3)}
-        >
-          <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
-            Volume Information
-            <span className="ml-2 text-xs text-blue-600 font-normal">(Click to edit)</span>
-          </h3>
-          <div className="grid grid-cols-1 gap-4 text-sm">
-            <div>
-              <span className=" text-gray-600 font-bold">Number of Events:</span>
-              <span className="ml-2 text-gray-800">{volumeInfo.nextYearEvents}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Online Gross Tickets Sales ($):</span>
-              <span className="ml-2 text-gray-800">{formatCurrency(volumeInfo.nextYearSales)}</span>
+            ))}
+            <div className="mt-1 pt-1 border-t border-gray-100 space-y-0.5">
+              <Row label="Single Entity" value={financesInfo.singleEntity ? 'Yes' : 'No'} />
+              <Row label="Business Debt" value={financesInfo.hasBusinessDebt ? 'Yes' : 'No'} />
+              <Row label="Tax Liens" value={financesInfo.hasTaxLiens ? 'Yes' : 'No'} />
+              <Row label="Overdue Liabilities" value={financesInfo.hasOverdueLiabilities ? 'Yes' : 'No'} />
+              <Row label="Bankruptcy" value={financesInfo.hasBankruptcy ? 'Yes' : 'No'} />
+              <Row label="Ownership Changed" value={financesInfo.ownershipChanged ? 'Yes' : 'No'} />
+              {financesInfo.industryReferences && <Row label="Industry References" value={financesInfo.industryReferences} />}
+              {financesInfo.additionalComments && <Row label="Additional Comments" value={financesInfo.additionalComments} />}
             </div>
           </div>
         </div>
 
-        {/* Funding Information */}
-        <div 
-          className="bg-white rounded-lg  p-6 cursor-pointer hover:bg-gray-50 transition-colors duration-200" 
-          onClick={() => onStepClick?.(4)}
-        >
-          <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
-            Funding Information
-            <span className="ml-2 text-xs text-blue-600 font-normal">(Click to edit)</span>
-          </h3>
-          <div className="grid grid-cols-1 gap-4 text-sm">
-            <div>
-              <span className=" text-gray-600 font-bold">Purchase Price:</span>
-              <span className="ml-2 text-gray-800">{formatCurrency(parseFloat(fundsInfo.yourFunds) || 0)}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Timing of Funding:</span>
-              <span className="ml-2 text-gray-800">{fundsInfo.timingOfFunding}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Use of Proceeds:</span>
-              <span className="ml-2 text-gray-800">{fundsInfo.useOfProceeds}</span>
-            </div>
-            
-          </div>
-        </div>
-
-        {/* Ownership Information */}
-        <div 
-          className="bg-white rounded-lg  p-6 cursor-pointer hover:bg-gray-50 transition-colors duration-200" 
-          onClick={() => onStepClick?.(5)}
-        >
-          <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
-            Ownership Information
-            <span className="ml-2 text-xs text-blue-600 font-normal">(Click to edit)</span>
-          </h3>
-          {ownershipInfo.owners.map((owner, index) => (
-            <div key={owner.id} className="mb-4 last:mb-0">
-              <h4 className="font-bold text-gray-700 mb-2 underline">Owner {index + 1}</h4>
-              <div className="grid grid-cols-1 gap-4 text-sm mb-4">
-                <div>
-                  <span className=" text-gray-600 font-bold">Name:</span>
-                  <span className="ml-2 text-gray-800">{owner.ownerName}</span>
+        {/* Step 4 — Diligence Files */}
+        <div className={cardClass} onClick={() => onStepClick?.(4)}>
+          <PencilIcon />
+          <h3 className="text-sm font-semibold text-gray-800 mb-2">Diligence Files</h3>
+          <div className="space-y-0.5">
+            {[
+              { label: 'Ticketing Company Report', key: 'ticketingCompanyReport' },
+              { label: 'Ticketing Service Agreement', key: 'ticketingServiceAgreement' },
+              { label: 'Financial Statements', key: 'financialStatements' },
+              { label: 'Bank Statement', key: 'bankStatement' },
+              { label: 'Incorporation Certificate', key: 'incorporationCertificate' },
+              { label: 'Legal Entity Chart', key: 'legalEntityChart' },
+              { label: 'Government ID', key: 'governmentId' },
+              { label: 'W9 Form', key: 'w9form' },
+              { label: 'Other Documents', key: 'other' },
+            ].map(({ label, key }) => {
+              const count = (diligenceInfo as any)[key].fileInfos.length;
+              return (
+                <div key={key} className="flex justify-between gap-2">
+                  <span className="text-gray-500 shrink-0">{label}:</span>
+                  <span className={count > 0 ? 'text-green-600 font-medium' : 'text-gray-400'}>
+                    {count > 0 ? `${count} file${count > 1 ? 's' : ''}` : 'No file'}
+                  </span>
                 </div>
-                <div>
-                  <span className=" text-gray-600 font-bold">Ownership Percentage:</span>
-                  <span className="ml-2 text-gray-800">{owner.ownershipPercentage}%</span>
-                </div>
-              </div>
-              <div className="grid grid-cols-1 gap-4 text-sm mb-4">
-                <div>
-                    <span className=" text-gray-600 font-bold">Address:</span>
-                  <span className="ml-2 text-gray-800">{owner.ownerAddress}</span>
-                </div>
-              </div>
-              <div className="grid grid-cols-1 gap-4 text-sm mb-4">
-                <div>
-                  <span className=" text-gray-600 font-bold">Birth Date:</span>
-                  <span className="ml-2 text-gray-800">{owner.ownerBirthDate}</span>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-
-        {/* Financial Information */}
-        <div 
-          className="bg-white rounded-lg  p-6 cursor-pointer hover:bg-gray-50 transition-colors duration-200" 
-          onClick={() => onStepClick?.(6)}
-        >
-          <h3 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
-            Financial Information
-            <span className="ml-2 text-xs text-blue-600 font-normal">(Click to edit)</span>
-          </h3>
-          <div className="grid grid-cols-2 gap-4 text-sm">
-            <div>
-              <span className=" text-gray-600 font-bold">Single Entity:</span>
-              <span className="ml-2 text-gray-800">{financesInfo.singleEntity ? 'Yes' : 'No'}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Has Business Debt:</span>
-              <span className="ml-2 text-gray-800">{financesInfo.hasBusinessDebt ? 'Yes' : 'No'}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Has Tax Liens:</span>
-              <span className="ml-2 text-gray-800">{financesInfo.hasTaxLiens ? 'Yes' : 'No'}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Has Overdue Liabilities:</span>
-              <span className="ml-2 text-gray-800">{financesInfo.hasOverdueLiabilities ? 'Yes' : 'No'}</span>
-            </div>
-         
-           
-          
-            <div>
-                <span className=" text-gray-600 font-bold">Has Bankruptcy:</span>
-              <span className="ml-2 text-gray-800">{financesInfo.hasBankruptcy ? 'Yes' : 'No'}</span>
-            </div>
-            <div>
-              <span className=" text-gray-600 font-bold">Ownership Changed:</span>
-              <span className="ml-2 text-gray-800">{financesInfo.ownershipChanged ? 'Yes' : 'No'}</span>
-            </div>
-          
-            {financesInfo.debts.length > 0 && (
-              <div className="col-span-2">
-                <span className=" text-gray-600 font-bold">Debts:</span>
-                <div className="ml-2 text-gray-800">
-                  {financesInfo.debts.map((debt, index) => (
-                    <div key={index} className="mb-1">
-                      {debt.type}: {formatCurrency(parseFloat(debt.balance) || 0)}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-            {financesInfo.industryReferences && (
-              <div className="col-span-2">
-                <span className=" text-gray-600 font-bold">Industry References:</span>
-                <span className="ml-2 text-gray-800">{financesInfo.industryReferences}</span>
-              </div>
-            )}
-            {financesInfo.additionalComments && (
-              <div className="col-span-2">
-                <span className=" text-gray-600 font-bold">Additional Comments:</span>
-                <span className="ml-2 text-gray-800">{financesInfo.additionalComments}</span>
-              </div>
-            )}
+              );
+            })}
           </div>
         </div>
 
-        {/* Due Diligence Files Summary */}
-        <div className="bg-white rounded-lg  p-6">
-          <h3 className="text-lg font-semibold text-gray-800 mb-4">Due Diligence Files</h3>
-          <div className="space-y-4">
-            <div className="flex items-center justify-between">
-              <span className=" text-gray-600 font-bold">Ticketing Company Report:</span>
-              <div className="flex items-center">
-                <span className="text-sm text-gray-800 mr-2">
-                  {diligenceInfo.ticketingCompanyReport.fileInfos.length} file(s)
-                </span>
-                <button 
-                  onClick={() => onStepClick?.(7)}
-                  className="text-sm text-blue-600 hover:text-blue-800 underline"
-                >
-                  Edit
-                </button>
-              </div>
-            </div>
-            <div className="flex items-center justify-between">
-              <span className=" text-gray-600 font-bold">Ticketing Service Agreement:</span>
-              <div className="flex items-center">
-                <span className="text-sm text-gray-800 mr-2">
-                  {diligenceInfo.ticketingServiceAgreement.fileInfos.length} file(s)
-                </span>
-                <button 
-                  onClick={() => onStepClick?.(7)}
-                  className="text-sm text-blue-600 hover:text-blue-800 underline"
-                >
-                  Edit
-                </button>
-              </div>
-            </div>
-            <div className="flex items-center justify-between">
-              <span className=" text-gray-600 font-bold">Financial Statements:</span>
-              <div className="flex items-center">
-                <span className="text-sm text-gray-800 mr-2">
-                  {diligenceInfo.financialStatements.fileInfos.length} file(s)
-                </span>
-                <button 
-                  onClick={() => onStepClick?.(8)}
-                  className="text-sm text-blue-600 hover:text-blue-800 underline"
-                >
-                  Edit
-                </button>
-              </div>
-            </div>
-            <div className="flex items-center justify-between">
-              <span className=" text-gray-600 font-bold">Bank Statement:</span>
-              <div className="flex items-center">
-                <span className="text-sm text-gray-800 mr-2">
-                  {diligenceInfo.bankStatement.fileInfos.length} file(s)
-                </span>
-                <button 
-                  onClick={() => onStepClick?.(8)}
-                  className="text-sm text-blue-600 hover:text-blue-800 underline"
-                >
-                  Edit
-                </button>
-              </div>
-            </div>
-            <div className="flex items-center justify-between">
-              <span className=" text-gray-600 font-bold">Incorporation Certificate:</span>
-              <div className="flex items-center">
-                <span className="text-sm text-gray-800 mr-2">
-                  {diligenceInfo.incorporationCertificate.fileInfos.length} file(s)
-                </span>
-                <button 
-                  onClick={() => onStepClick?.(9)}
-                  className="text-sm text-blue-600 hover:text-blue-800 underline"
-                >
-                  Edit
-                </button>
-              </div>
-            </div>
-            <div className="flex items-center justify-between">
-                  <span className=" text-gray-600 font-bold">Legal Entity Chart:</span>
-              <div className="flex items-center">
-                <span className="text-sm text-gray-800 mr-2">
-                  {diligenceInfo.legalEntityChart.fileInfos.length} file(s)
-                </span>
-                <button 
-                  onClick={() => onStepClick?.(9)}
-                  className="text-sm text-blue-600 hover:text-blue-800 underline"
-                >
-                  Edit
-                </button>
-              </div>
-            </div>
-            <div className="flex items-center justify-between">
-              <span className=" text-gray-600 font-bold">Government ID:</span>
-              <div className="flex items-center">
-                <span className="text-sm text-gray-800 mr-2">
-                  {diligenceInfo.governmentId.fileInfos.length} file(s)
-                </span>
-                <button 
-                  onClick={() => onStepClick?.(9)}
-                  className="text-sm text-blue-600 hover:text-blue-800 underline"
-                >
-                  Edit
-                </button>
-              </div>
-            </div>
-            <div className="flex items-center justify-between">
-              <span className=" text-gray-600 font-bold">W9 Form:</span>
-              <div className="flex items-center">
-                <span className="text-sm text-gray-800 mr-2">
-                  {diligenceInfo.w9form.fileInfos.length} file(s)
-                </span>
-                <button 
-                  onClick={() => onStepClick?.(9)}
-                  className="text-sm text-blue-600 hover:text-blue-800 underline"
-                >
-                  Edit
-                </button>
-              </div>
-            </div>
-    
-            <div className="flex items-center justify-between">
-              <span className=" text-gray-600 font-bold">Other Documents:</span>
-              <div className="flex items-center">
-                <span className="text-sm text-gray-800 mr-2">
-                  {diligenceInfo.other.fileInfos.length} file(s)
-                </span>
-                <button 
-                  onClick={() => onStepClick?.(10)}
-                  className="text-sm text-blue-600 hover:text-blue-800 underline"
-                >
-                  Edit
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-       
-      </div> 
-
-     
+      </div>
     </div>
   );
 };
 
-export default SummaryStep; 
+export default SummaryStep;

--- a/src/store/form/hubspotLists.ts
+++ b/src/store/form/hubspotLists.ts
@@ -113,7 +113,7 @@ export const clientType = {
     'Frontgate':'Frontgate',  
     'Leap Event Technology':'Leap Event Technology',
     'PreKindle':'PreKindle',
-    'See Tickets':'See Tickets',
+    'See Tickets':'Eventim/See Tickets',
     'Shotgun':'Shotgun',
     'Showpass':'Showpass',
     'SquadUp':'SquadUp',


### PR DESCRIPTION
Port des changements UI de la branche `52-improve-design` sur la base `main-new`.

## Modifications

- **StepTitle** : titres plus grands et plus gras (Ticketing, Finance, Contractual & Legal)
- **FileUploadField** : zone drag & drop compacte, liste des fichiers en chips, « Click to select » en orange, titres/descriptions réduits
- **Finances** : tooltip multi-entity aligné à droite, largeur fixe pour mobile, z-50
- **SummaryStep** : 4 cards (Business Info, Funding, Business & Ownership, Diligence Files) avec icône crayon, layout compact
- **MultiStepForm** : `overflow-x-clip` pour éviter que le tooltip soit coupé
- Inclus aussi les éventuelles modifs step4 / hubspotLists présentes sur la branche

## Base

Branche créée depuis `main-new`, aucun changement de logique métier (auth, API, etc.).

Made with [Cursor](https://cursor.com)