### PR TITLE
feat(auth): customer link password via webhook when companyName in URL

### DIFF
--- a/env.example
+++ b/env.example
@@ -9,8 +9,12 @@ REACT_APP_WEBHOOK_URL_FILES=
 REACT_APP_HUBSPOT_COMPANY_ID=
 REACT_APP_HUBSPOT_DEAL_ID=
 
-# Mot de passe pour protéger l'accès au formulaire
+# Mot de passe pour protéger l'accès au formulaire (lien générique sans companyName)
 REACT_APP_FORM_PASSWORD=your_secure_password_here
+
+# Webhook Make.com pour vérifier le mot de passe des liens client (?companyName=...)
+# Le scénario reçoit { companyName, password } et renvoie true/false (ou { valid: true })
+REACT_APP_CHECK_PASSWORD_CUSTOMER_LINK_WEBHOOK=
 
 # Instructions:
 # 1. Copiez ce fichier vers .env

--- a/src/components/PasswordProtection.tsx
+++ b/src/components/PasswordProtection.tsx
@@ -2,49 +2,59 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import logo from '../assets/logo_white_bold.svg';
 import background from '../assets/background.jpeg';
+import { getCompanyNameFromUrl } from '../utils/urlParams';
+
 const PasswordProtection: React.FC = () => {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
+  const onChangePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value.length > 0) {
+      if (e.target.value.trim() === '') {
+        setError('Password cannot be empty or contain only spaces');
+      } else if (e.target.value.length < 6) {
+        setError('Password must be at least 6 characters long');
+      } else {
+        setError('');
+      }
+    } else {
+      setError('');
+    }
+    setPassword(e.target.value);
+  };
 
-
-const onChangePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
-  if(e.target.value.length > 0){
-  if (e.target.value.trim() === '') {
-    setError('Password cannot be empty or contain only spaces');
-  } else if(e.target.value.length < 6){
-    setError('Password must be at least 6 characters long');
- } else {
-    setError('');
-  }
-} else {
-  setError('');
-}
-setPassword(e.target.value);
-
-}
-
-
-
-  
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
-   
-
     setLoading(true);
     setError('');
 
     try {
-      // Récupérer le mot de passe depuis les variables d'environnement
-      const correctPassword = process.env.REACT_APP_FORM_PASSWORD;
-    
-      if (password === correctPassword) {
-        // Stocker l'authentification dans le localStorage
+      const companyName = getCompanyNameFromUrl();
+      const webhookUrl = process.env.REACT_APP_CHECK_PASSWORD_CUSTOMER_LINK_WEBHOOK?.trim();
+
+      if (!webhookUrl) {
+        setError('Configuration error. Please contact support.');
+        return;
+      }
+
+      const response = await fetch(webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ companyName, password }),
+      });
+
+      if (!response.ok) {
+        setError('Incorrect password');
+        return;
+      }
+
+      const data = await response.json();
+      const isValid = data === true || data === 'true' || data?.valid === true || data?.success === true || data?.isPasswordValid === true;
+
+      if (isValid) {
         localStorage.setItem('formAuthenticated', 'true');
-        // Rediriger vers le formulaire
         navigate('/form');
       } else {
         setError('Incorrect password');
@@ -81,7 +91,7 @@ setPassword(e.target.value);
         <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
           
 
-          <form className="space-y-6" onSubmit={ error ? () => {} : handleSubmit}>
+          <form className="space-y-6" onSubmit={(e) => { e.preventDefault(); if (!error) handleSubmit(e); }}>
             <div>
               <label htmlFor="password" className="block text-sm font-medium text-gray-700">
                 Password

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import PasswordProtection from './PasswordProtection';
+import { getCompanyNameFromUrl } from '../utils/urlParams';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -11,12 +12,16 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   const location = useLocation();
 
   useEffect(() => {
-    // Vérifier si l'utilisateur est authentifié
+    const companyNameInUrl = getCompanyNameFromUrl();
+    // Si companyName est dans l'URL = lien client dédié → exiger le mot de passe
+    if (!companyNameInUrl) {
+      setIsAuthenticated(true);
+      return;
+    }
     const authenticated = localStorage.getItem('formAuthenticated') === 'true';
     setIsAuthenticated(authenticated);
   }, [location]);
 
-  // Afficher un loader pendant la vérification
   if (isAuthenticated === null) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
@@ -25,12 +30,10 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
     );
   }
 
-  // Si authentifié, afficher le contenu protégé
   if (isAuthenticated) {
     return <>{children}</>;
   }
 
-  // Sinon, afficher la page de protection par mot de passe
   return <PasswordProtection />;
 };
 

--- a/src/utils/urlParams.ts
+++ b/src/utils/urlParams.ts
@@ -1,0 +1,9 @@
+/**
+ * Récupère le companyName depuis l'URL (?companyName=...).
+ * Utilisé pour décider si l'écran mot de passe doit être affiché (lien client avec companyName = protection).
+ */
+export const getCompanyNameFromUrl = (): string => {
+  if (typeof window === 'undefined') return '';
+  const params = new URLSearchParams(window.location.search);
+  return params.get('companyName')?.trim() || '';
+};


### PR DESCRIPTION
- Add getCompanyNameFromUrl() in urlParams.ts
- ProtectedRoute: show password only when ?companyName= in URL; else direct access
- PasswordProtection: verify password via REACT_APP_CHECK_PASSWORD_CUSTOMER_LINK_WEBHOOK (POST { companyName, password }), accept { isPasswordValid: true } response
- Fix form submit: always preventDefault to avoid password in URL
- env.example: document REACT_APP_CHECK_PASSWORD_CUSTOMER_LINK_WEBHOOK

Made-with: Cursor