### PR TITLE
feat(underwriting): expand diligence uploads and validation flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "start": "PORT=3001 react-scripts start",
     "build": "react-scripts build",
     "eject": "react-scripts eject",
+    "test": "react-scripts test --watchAll=false",
     "test:e2e:prod": "playwright test tests/prod-form-critical-path.spec.ts"
   },
   "eslintConfig": {

--- a/src/components/MultiStepForm.tsx
+++ b/src/components/MultiStepForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { RootState, AppDispatch } from '../store';
@@ -20,6 +20,7 @@ import { useFormValidation } from '../hooks/useFormValidation';
 import '../utils/debugUtils';
 import { getTicketingCoFromUrl, getTicketingPartnerLogo, isValidTicketingPartner } from '../utils/ticketingPartnerUtils';
 import { logCriticalEvent } from '../utils/criticalLogging';
+import { buildUnderwritingWebhookCompanyFields } from '../utils/underwritingFields';
 
 const MultiStepFormContent: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
@@ -28,7 +29,9 @@ const MultiStepFormContent: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const formData = useSelector((state: RootState) => state.form);
   const [saveMessage, setSaveMessage] = useState('');
-  const { sendFormData, isUploading } = useFileUpload();
+  const { sendFormData } = useFileUpload();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const submitInFlightRef = useRef(false);
   const { validateAllSteps, validateCurrentStep, isDevelopment } = useFormValidation();
   
   // Vérifier l'environnement (development, staging, production)
@@ -51,6 +54,12 @@ const MultiStepFormContent: React.FC = () => {
   }, [isSubmitted, navigate]);
 
   const handleSubmit = async () => {
+    if (submitInFlightRef.current || isSubmitted) {
+      return;
+    }
+
+    submitInFlightRef.current = true;
+    setIsSubmitting(true);
     setSaveMessage('');
     const submitStartedAt = Date.now();
 
@@ -77,6 +86,16 @@ const MultiStepFormContent: React.FC = () => {
           otherPartner: formData.formData.ticketingInfo.otherPartner,
           paymentProcessing: formData.formData.ticketingInfo.paymentProcessing,
           settlementPayout: formData.formData.ticketingInfo.settlementPayout,
+          ...buildUnderwritingWebhookCompanyFields(
+            {
+              paymentProcessor: formData.formData.ticketingInfo.paymentProcessor,
+              otherPaymentProcessor: formData.formData.ticketingInfo.otherPaymentProcessor,
+            },
+            {
+              accountingSystem: formData.formData.financesInfo.accountingSystem,
+              otherAccountingSystem: formData.formData.financesInfo.otherAccountingSystem,
+            }
+          ),
           nextYearEvents: formData.formData.volumeInfo.nextYearEvents,
           nextYearSales: formData.formData.volumeInfo.nextYearSales,
           owners: formData.formData.ownershipInfo.owners,
@@ -120,11 +139,6 @@ const MultiStepFormContent: React.FC = () => {
         setSaveMessage('Application submitted successfully!');
         
         dispatch(setSubmitted());
-
-        // Navigate to success page after a delay
-        setTimeout(() => {
-          navigate('/submit-success');
-        }, 2000);
       } else {
         logCriticalEvent({
           event_name: 'form_submission_failed',
@@ -151,9 +165,16 @@ const MultiStepFormContent: React.FC = () => {
 
       console.error('Submission error:', error);
       setSaveMessage(error instanceof Error ? error.message : 'Failed to submit application. Please try again.');
-    } 
+      submitInFlightRef.current = false;
+      setIsSubmitting(false);
+    }
   };
+
   const triggerValidationThenSubmit = () => {
+    if (submitInFlightRef.current || isSubmitting || isSubmitted) {
+      return;
+    }
+
     const validation = validateAllSteps();
     
     if (!validation.isValid) {
@@ -174,7 +195,7 @@ const MultiStepFormContent: React.FC = () => {
     }
 
     setValidationErrors(null);
-    handleSubmit();
+    void handleSubmit();
   };
 
   const handleNextStep = async () => {
@@ -436,7 +457,7 @@ const MultiStepFormContent: React.FC = () => {
           {/* Navigation Buttons */}
           <div className="flex gap-4 w-full mx-auto mt-4  justify-center">
             {currentStep === 1 && (
-              <ButtonPrimary className='lg:first:w-[40%] ' onClick={handleNextStep} disabled={isSavingStep}>
+              <ButtonPrimary className='lg:first:w-[40%] ' onClick={handleNextStep} disabled={isSavingStep || isSubmitting}>
                 {isSavingStep ? (
                   <div className="flex items-center gap-2">
                     <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
@@ -448,11 +469,11 @@ const MultiStepFormContent: React.FC = () => {
               </ButtonPrimary>
             )}
             {currentStep > 1 && (
-              <ButtonSecondary onClick={handlePreviousStep} disabled={false}>Previous</ButtonSecondary>
+              <ButtonSecondary onClick={handlePreviousStep} disabled={isSubmitting}>Previous</ButtonSecondary>
             )}
 
             {(currentStep < 5 && currentStep > 1) && (
-              <ButtonPrimary onClick={handleNextStep} disabled={isSavingStep}>
+              <ButtonPrimary onClick={handleNextStep} disabled={isSavingStep || isSubmitting}>
                 {isSavingStep ? (
                   <div className="flex items-center gap-2">
                     <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
@@ -464,9 +485,19 @@ const MultiStepFormContent: React.FC = () => {
               </ButtonPrimary>
             )}
             {currentStep === 5 && (
-              <ButtonPrimary onClick={() => {
-                triggerValidationThenSubmit();
-              }} disabled={false}>Submit</ButtonPrimary>
+              <ButtonPrimary
+                onClick={triggerValidationThenSubmit}
+                disabled={isSubmitting || isSubmitted}
+              >
+                {isSubmitting ? (
+                  <div className="flex items-center gap-2">
+                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                    <span>Submitting...</span>
+                  </div>
+                ) : (
+                  'Submit'
+                )}
+              </ButtonPrimary>
             )}
                     </div>
  {/* Success/Error Message */}
@@ -479,8 +510,7 @@ const MultiStepFormContent: React.FC = () => {
           </div>
         )}
 
-        {/* Submission in progress */}
-        {isUploading && (
+        {isSubmitting && (
           <div className="w-full mx-auto my-4 p-4 rounded-lg bg-blue-50 border border-blue-200">
             <div className="text-center">
               <div className="inline-block animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600 mr-2"></div>

--- a/src/components/customComponents/ButtonPrimary.tsx
+++ b/src/components/customComponents/ButtonPrimary.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 
 const ButtonPrimary = ({ children, onClick, disabled, className }: { children: React.ReactNode, onClick: () => void, disabled: boolean, className?: string }) => {
     return (
-        <button 
-            onClick={onClick} 
-            disabled={disabled} 
+        <button
+            type="button"
+            onClick={onClick}
+            disabled={disabled}
             className={`
                 ${className || ''} 
                 px-6 py-2.5 

--- a/src/components/customComponents/FileUploadField.tsx
+++ b/src/components/customComponents/FileUploadField.tsx
@@ -11,7 +11,8 @@ interface FileUploadFieldProps {
   multiple?: boolean;
   className?: string;
   onFilesChange?: (fileInfos: any[]) => void;
-  title?: string;
+  title?: React.ReactNode;
+  uploadPeriods?: string[];
   required?: boolean;
   error?: string;
 }
@@ -24,6 +25,7 @@ const FileUploadField: React.FC<FileUploadFieldProps> = ({
   className = "",
   onFilesChange,
   title = "",
+  uploadPeriods,
   required = false,
   error = ''
 }) => {
@@ -393,9 +395,22 @@ const FileUploadField: React.FC<FileUploadFieldProps> = ({
   }; */
 
   return (  
-    <div className={`flex flex-col w-full mb-6 ${className}`}>
+    <div className={`flex flex-col w-full mb-6 ${className}`} data-field-name={field}>
       <h4 className="text-xs font-semibold text-neutral-700 leading-tight">{title}</h4>
-      {description && <p className="text-[10px] font-300 text-gray-400 leading-tight" dangerouslySetInnerHTML={{ __html: description }} />}
+      {uploadPeriods && uploadPeriods.length > 0 && (
+        <p className="mt-1.5 flex flex-wrap items-center gap-1.5">
+          <span className="text-[10px] text-gray-500">One file each for</span>
+          {uploadPeriods.map((period) => (
+            <span
+              key={period}
+              className="inline-flex rounded-full bg-orange-50 px-2 py-0.5 text-[10px] font-medium text-orange-900 ring-1 ring-orange-200/80"
+            >
+              {period}
+            </span>
+          ))}
+        </p>
+      )}
+      {description && <p className="text-[10px] font-300 text-gray-400 leading-tight mt-1" dangerouslySetInnerHTML={{ __html: description }} />}
       
       <div
         className={`relative border-2 border-dashed rounded-lg px-4 py-3 mt-2 text-center transition-colors ${

--- a/src/components/step1/TicketingInformations.tsx
+++ b/src/components/step1/TicketingInformations.tsx
@@ -1,19 +1,20 @@
 import React, { useEffect }  from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../store';
-import { updateTicketingInfo, updateVolumeInfo } from '../../store/form/formSlice';
+import { updateFinancesInfo, updateTicketingInfo, updateVolumeInfo } from '../../store/form/formSlice';
 import StepTitle from '../customComponents/StepTitle';
 import DropdownField from '../customComponents/DropdownField';
 import TextField from '../customComponents/TextField';
 import NumberInput from '../customComponents/NumberField';
 import CurrencyField from '../customComponents/CurrencyField';
 import { useValidation } from '../../contexts/ValidationContext';
-import { paymentProcessing, ticketingPartners, settlementPayout } from '../../store/form/hubspotLists';
+import { accountingSystemOptions, paymentProcessing, paymentProcessorOptions, ticketingPartners, settlementPayout } from '../../store/form/hubspotLists';
 import { findTicketingPartnerKey, getTicketingCoFromUrl } from '../../utils/ticketingPartnerUtils';
 
 const TicketingFundingStep: React.FC = () => {
   const dispatch = useDispatch();
   const ticketingInfo = useSelector((state: RootState) => state.form.formData.ticketingInfo);
+  const financesInfo = useSelector((state: RootState) => state.form.formData.financesInfo);
   const ticketingVolume = useSelector((state: RootState) => state.form.formData.volumeInfo);
   const { setFieldError } = useValidation();
   const ticketingCoParam = getTicketingCoFromUrl();
@@ -39,6 +40,12 @@ const TicketingFundingStep: React.FC = () => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
     dispatch(updateTicketingInfo({ [name]: value }));
+    setFieldError(name, null);
+  };
+
+  const handleFinancesChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    dispatch(updateFinancesInfo({ [name]: value }));
     setFieldError(name, null);
   };
 
@@ -79,6 +86,18 @@ const TicketingFundingStep: React.FC = () => {
      )}
 
       <DropdownField label="What is the payout/settlement policy?" name="settlementPayout" value={ticketingInfo.settlementPayout} onChange={handleChange} error='' onBlur={() => { }} options={settlementPayout} required />
+
+      <DropdownField label="Payment Processor" name="paymentProcessor" value={ticketingInfo.paymentProcessor} onChange={handleChange} error='' onBlur={() => { }} options={paymentProcessorOptions} required />
+
+      {ticketingInfo.paymentProcessor === 'Other' && (
+        <TextField label="Other Payment Processor" name="otherPaymentProcessor" value={ticketingInfo.otherPaymentProcessor} onChange={handleChange} error='' onBlur={() => { }} type='text' required />
+      )}
+
+      <DropdownField label="Accounting System" name="accountingSystem" value={financesInfo.accountingSystem} onChange={handleFinancesChange} error='' onBlur={() => { }} options={accountingSystemOptions} required />
+
+      {financesInfo.accountingSystem === 'Other' && (
+        <TextField label="Other Accounting System" name="otherAccountingSystem" value={financesInfo.otherAccountingSystem} onChange={handleFinancesChange} error='' onBlur={() => { }} type='text' required />
+      )}
 
     </div>
   );

--- a/src/components/step4/FinancialInformationStep.tsx
+++ b/src/components/step4/FinancialInformationStep.tsx
@@ -3,27 +3,56 @@ import React from 'react';
 import StepTitle from '../customComponents/StepTitle';
 import FileUploadField from '../customComponents/FileUploadField';
 
+const FINANCIAL_UPLOAD_SECTIONS = [
+  {
+    period: 'Year To Date',
+    uploads: [
+      { field: 'financialsYtdPL', title: 'P&L' },
+      { field: 'financialsYtdBS', title: 'Balance Sheet' },
+    ],
+  },
+  {
+    period: 'Year - 1',
+    uploads: [
+      { field: 'financialsYear1PL', title: 'P&L' },
+      { field: 'financialsYear1BS', title: 'Balance Sheet' },
+    ],
+  },
+  {
+    period: 'Year - 2',
+    uploads: [
+      { field: 'financialsYear2PL', title: 'P&L' },
+      { field: 'financialsYear2BS', title: 'Balance Sheet' },
+    ],
+  },
+] as const;
+
 const FinancialInformationStep: React.FC = () => {
-
-
-  const handleFilesChange = (field: string, fileInfos: any[]) => {
-    // This will be called when files are added/removed
-    // The actual files are managed by the FileUploadField component
+  const handleFilesChange = (_field: string, _fileInfos: unknown[]) => {
+    // Files are managed by FileUploadField
   };
 
   return (
     <div className="flex flex-col w-full animate-fade-in-right duration-1000">
       <StepTitle title="2. Finance" />
-      
-      <div className="w-full">  
-        <FileUploadField
-          field="financialStatements"
-          title="Last 2 years and YTD detailed financial statements (P&L, B/S) per month"
-          accept=".xlsx,.pdf,.csv,.jpg,.png"
-          multiple={true}
-          onFilesChange={(fileInfos) => handleFilesChange('financialStatements', fileInfos)}
-          required={true}
-        />
+
+      <div className="w-full">
+        {FINANCIAL_UPLOAD_SECTIONS.map(({ period, uploads }) => (
+          <div key={period} className="mb-2">
+            <p className="text-xs font-semibold text-neutral-800 mb-2">{period}</p>
+            {uploads.map(({ field, title }) => (
+              <FileUploadField
+                key={field}
+                field={field}
+                title={title}
+                accept=".xlsx,.pdf,.csv,.jpg,.png"
+                multiple={false}
+                onFilesChange={(fileInfos) => handleFilesChange(field, fileInfos)}
+                required={true}
+              />
+            ))}
+          </div>
+        ))}
 
         <FileUploadField
           field="bankStatement"
@@ -37,4 +66,4 @@ const FinancialInformationStep: React.FC = () => {
   );
 };
 
-export default FinancialInformationStep; 
+export default FinancialInformationStep;

--- a/src/components/step4/TicketingInformationStep.tsx
+++ b/src/components/step4/TicketingInformationStep.tsx
@@ -35,6 +35,25 @@ const TicketingInformationStep: React.FC = () => {
           required={ticketingInfo.paymentProcessing === 'Venue' ? true : false}
         />
 
+        <FileUploadField
+          field="futureEventSchedule"
+          title="Schedule of Future Events"
+          description="Upload the schedule of future events you are seeking financing for"
+          accept=".xlsx,.pdf,.csv,.jpg,.png"
+          multiple={true}
+          onFilesChange={(fileInfos) => handleFilesChange('futureEventSchedule', fileInfos)}
+          required={true}
+        />
+
+        <FileUploadField
+          field="venueAgreements"
+          title="Venue Agreements"
+          accept=".xlsx,.pdf,.csv,.jpg,.png"
+          multiple={true}
+          onFilesChange={(fileInfos) => handleFilesChange('venueAgreements', fileInfos)}
+          required={true}
+        />
+
       </div>
     </div>
   );

--- a/src/components/step5/SummaryStep.tsx
+++ b/src/components/step5/SummaryStep.tsx
@@ -62,6 +62,14 @@ const SummaryStep: React.FC<SummaryStepProps> = ({ renderValidationErrors, onSte
             <Row label="Ticketing Partner" value={ticketingInfo.currentPartner} />
             <Row label="Settlement From" value={ticketingInfo.paymentProcessing} />
             <Row label="Settlement Policy" value={ticketingInfo.settlementPayout} />
+            <Row label="Payment Processor" value={ticketingInfo.paymentProcessor} />
+            {ticketingInfo.paymentProcessor === 'Other' && (
+              <Row label="Other Payment Processor" value={ticketingInfo.otherPaymentProcessor} />
+            )}
+            <Row label="Accounting System" value={financesInfo.accountingSystem} />
+            {financesInfo.accountingSystem === 'Other' && (
+              <Row label="Other Accounting System" value={financesInfo.otherAccountingSystem} />
+            )}
             <Row label="Events / Year" value={volumeInfo.nextYearEvents} />
             <Row label="Gross Ticketing Volume" value={formatCurrency(volumeInfo.nextYearSales)} />
           </div>
@@ -111,9 +119,16 @@ const SummaryStep: React.FC<SummaryStepProps> = ({ renderValidationErrors, onSte
           <h3 className="text-sm font-semibold text-gray-800 mb-2">Diligence Files</h3>
           <div className="space-y-0.5">
             {[
+              { label: 'Future Event Schedule', key: 'futureEventSchedule' },
               { label: 'Ticketing Company Report', key: 'ticketingCompanyReport' },
               { label: 'Ticketing Service Agreement', key: 'ticketingServiceAgreement' },
-              { label: 'Financial Statements', key: 'financialStatements' },
+              { label: 'Year To Date — P&L', key: 'financialsYtdPL' },
+              { label: 'Year To Date — Balance Sheet', key: 'financialsYtdBS' },
+              { label: 'Year - 1 — P&L', key: 'financialsYear1PL' },
+              { label: 'Year - 1 — Balance Sheet', key: 'financialsYear1BS' },
+              { label: 'Year - 2 — P&L', key: 'financialsYear2PL' },
+              { label: 'Year - 2 — Balance Sheet', key: 'financialsYear2BS' },
+              { label: 'Venue Agreements', key: 'venueAgreements' },
               { label: 'Bank Statement', key: 'bankStatement' },
               { label: 'Incorporation Certificate', key: 'incorporationCertificate' },
               { label: 'Legal Entity Chart', key: 'legalEntityChart' },
@@ -121,7 +136,7 @@ const SummaryStep: React.FC<SummaryStepProps> = ({ renderValidationErrors, onSte
               { label: 'W9 Form', key: 'w9form' },
               { label: 'Other Documents', key: 'other' },
             ].map(({ label, key }) => {
-              const count = (diligenceInfo as any)[key].fileInfos.length;
+              const count = (diligenceInfo as any)[key]?.fileInfos?.length ?? 0;
               return (
                 <div key={key} className="flex justify-between gap-2">
                   <span className="text-gray-500 shrink-0">{label}:</span>

--- a/src/contexts/DiligenceFilesContext.tsx
+++ b/src/contexts/DiligenceFilesContext.tsx
@@ -15,7 +15,6 @@ export interface FileUploadStatus {
 interface DiligenceFiles {
   ticketingCompanyReport: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
   ticketingServiceAgreement: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
-  financialStatements: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
   bankStatement: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
   incorporationCertificate: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
   legalEntityChart: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
@@ -23,6 +22,14 @@ interface DiligenceFiles {
   w9form: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
   lastYearTaxes: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
   other: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
+  futureEventSchedule: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
+  financialsYtdPL: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
+  financialsYtdBS: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
+  financialsYear1PL: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
+  financialsYear1BS: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
+  financialsYear2PL: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
+  financialsYear2BS: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
+  venueAgreements: { files: File[]; fileInfos: FileInfo[]; uploadStatuses: FileUploadStatus[] };
 }
 
 interface DiligenceFilesContextType {
@@ -40,7 +47,6 @@ const DiligenceFilesContext = createContext<DiligenceFilesContextType | undefine
 const initialDiligenceFiles: DiligenceFiles = {
   ticketingCompanyReport: { files: [], fileInfos: [], uploadStatuses: [] },
   ticketingServiceAgreement: { files: [], fileInfos: [], uploadStatuses: [] },
-  financialStatements: { files: [], fileInfos: [], uploadStatuses: [] },
   bankStatement: { files: [], fileInfos: [], uploadStatuses: [] },
   incorporationCertificate: { files: [], fileInfos: [], uploadStatuses: [] },
   legalEntityChart: { files: [], fileInfos: [], uploadStatuses: [] },
@@ -48,6 +54,14 @@ const initialDiligenceFiles: DiligenceFiles = {
   w9form: { files: [], fileInfos: [], uploadStatuses: [] },
   lastYearTaxes: { files: [], fileInfos: [], uploadStatuses: [] },
   other: { files: [], fileInfos: [], uploadStatuses: [] },
+  futureEventSchedule: { files: [], fileInfos: [], uploadStatuses: [] },
+  financialsYtdPL: { files: [], fileInfos: [], uploadStatuses: [] },
+  financialsYtdBS: { files: [], fileInfos: [], uploadStatuses: [] },
+  financialsYear1PL: { files: [], fileInfos: [], uploadStatuses: [] },
+  financialsYear1BS: { files: [], fileInfos: [], uploadStatuses: [] },
+  financialsYear2PL: { files: [], fileInfos: [], uploadStatuses: [] },
+  financialsYear2BS: { files: [], fileInfos: [], uploadStatuses: [] },
+  venueAgreements: { files: [], fileInfos: [], uploadStatuses: [] },
 };
 
 interface DiligenceFilesProviderProps {
@@ -86,11 +100,6 @@ export const DiligenceFilesProvider: React.FC<DiligenceFilesProviderProps> = ({ 
           fileInfos: reduxDiligenceInfo.ticketingServiceAgreement?.fileInfos || [],
           uploadStatuses: [] 
         },
-        financialStatements: { 
-          files: reduxDiligenceInfo.financialStatements?.files || [], 
-          fileInfos: reduxDiligenceInfo.financialStatements?.fileInfos || [],
-          uploadStatuses: [] 
-        },
         bankStatement: { 
           files: reduxDiligenceInfo.bankStatement?.files || [], 
           fileInfos: reduxDiligenceInfo.bankStatement?.fileInfos || [],
@@ -125,6 +134,46 @@ export const DiligenceFilesProvider: React.FC<DiligenceFilesProviderProps> = ({ 
           files: reduxDiligenceInfo.lastYearTaxes?.files || [], 
           fileInfos: reduxDiligenceInfo.lastYearTaxes?.fileInfos || [],
           uploadStatuses: [] 
+        },
+        futureEventSchedule: {
+          files: reduxDiligenceInfo.futureEventSchedule?.files || [],
+          fileInfos: reduxDiligenceInfo.futureEventSchedule?.fileInfos || [],
+          uploadStatuses: [],
+        },
+        financialsYtdPL: {
+          files: reduxDiligenceInfo.financialsYtdPL?.files || [],
+          fileInfos: reduxDiligenceInfo.financialsYtdPL?.fileInfos || [],
+          uploadStatuses: [],
+        },
+        financialsYtdBS: {
+          files: reduxDiligenceInfo.financialsYtdBS?.files || [],
+          fileInfos: reduxDiligenceInfo.financialsYtdBS?.fileInfos || [],
+          uploadStatuses: [],
+        },
+        financialsYear1PL: {
+          files: reduxDiligenceInfo.financialsYear1PL?.files || [],
+          fileInfos: reduxDiligenceInfo.financialsYear1PL?.fileInfos || [],
+          uploadStatuses: [],
+        },
+        financialsYear1BS: {
+          files: reduxDiligenceInfo.financialsYear1BS?.files || [],
+          fileInfos: reduxDiligenceInfo.financialsYear1BS?.fileInfos || [],
+          uploadStatuses: [],
+        },
+        financialsYear2PL: {
+          files: reduxDiligenceInfo.financialsYear2PL?.files || [],
+          fileInfos: reduxDiligenceInfo.financialsYear2PL?.fileInfos || [],
+          uploadStatuses: [],
+        },
+        financialsYear2BS: {
+          files: reduxDiligenceInfo.financialsYear2BS?.files || [],
+          fileInfos: reduxDiligenceInfo.financialsYear2BS?.fileInfos || [],
+          uploadStatuses: [],
+        },
+        venueAgreements: {
+          files: reduxDiligenceInfo.venueAgreements?.files || [],
+          fileInfos: reduxDiligenceInfo.venueAgreements?.fileInfos || [],
+          uploadStatuses: [],
         },
       };
       

--- a/src/hooks/useDiligenceValidation.ts
+++ b/src/hooks/useDiligenceValidation.ts
@@ -13,10 +13,15 @@ export const useDiligenceValidation = () => {
   };
 
   const validateFinancialInformation = (): boolean => {
-    return (
-      diligenceInfo.financialStatements.fileInfos.length > 0 &&
-      diligenceInfo.bankStatement.fileInfos.length > 0
-    );
+    const hasRequiredFinancialDocuments =
+      diligenceInfo.financialsYtdPL.fileInfos.length > 0 &&
+      diligenceInfo.financialsYtdBS.fileInfos.length > 0 &&
+      diligenceInfo.financialsYear1PL.fileInfos.length > 0 &&
+      diligenceInfo.financialsYear1BS.fileInfos.length > 0 &&
+      diligenceInfo.financialsYear2PL.fileInfos.length > 0 &&
+      diligenceInfo.financialsYear2BS.fileInfos.length > 0;
+
+    return hasRequiredFinancialDocuments && diligenceInfo.bankStatement.fileInfos.length > 0;
   };
 
   const validateLegalInformation = (): boolean => {
@@ -49,8 +54,23 @@ export const useDiligenceValidation = () => {
     }
 
     // Validation Financial Information
-    if (diligenceInfo.financialStatements.fileInfos.length === 0) {
-      errors.push('Financial statements are required');
+    if (diligenceInfo.financialsYtdPL.fileInfos.length === 0) {
+      errors.push('Year To Date — P&L is required');
+    }
+    if (diligenceInfo.financialsYtdBS.fileInfos.length === 0) {
+      errors.push('Year To Date — Balance Sheet is required');
+    }
+    if (diligenceInfo.financialsYear1PL.fileInfos.length === 0) {
+      errors.push('Year - 1 — P&L is required');
+    }
+    if (diligenceInfo.financialsYear1BS.fileInfos.length === 0) {
+      errors.push('Year - 1 — Balance Sheet is required');
+    }
+    if (diligenceInfo.financialsYear2PL.fileInfos.length === 0) {
+      errors.push('Year - 2 — P&L is required');
+    }
+    if (diligenceInfo.financialsYear2BS.fileInfos.length === 0) {
+      errors.push('Year - 2 — Balance Sheet is required');
     }
     if (diligenceInfo.bankStatement.fileInfos.length === 0) {
       errors.push('Bank statements are required');

--- a/src/hooks/useFileUpload.ts
+++ b/src/hooks/useFileUpload.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { logCriticalEvent } from '../utils/criticalLogging';
+import { getUploadLabelForField } from '../utils/underwritingFields';
 
 interface UploadResult {
   success: boolean;
@@ -172,31 +173,6 @@ export const useFileUpload = () => {
     }
   };
 
-  // Mapping des champs vers leurs dossiers Google Drive
-  const getGoogleDriveFolders = (fieldName: string): { folder: string; subFolder: string } => {
-    const folderMapping: { [key: string]: { folder: string; subFolder: string } } = {
-      // Ticketing Information
-      'ticketingCompanyReport': { folder: 'Ticketing Information', subFolder: 'Ticketing Report' },
-      'ticketingServiceAgreement': { folder: 'Ticketing Information', subFolder: 'Service Agreement' },
-      
-      // Financial Information
-      'financialStatements': { folder: 'Financial Information', subFolder: 'Financial Statements' },
-      'bankStatement': { folder: 'Financial Information', subFolder: 'Bank Statements' },
-      'lastYearTaxes': { folder: 'Financial Information', subFolder: 'Last Year Taxes' },
-      
-      // Legal Information
-      'incorporationCertificate': { folder: 'Legal Information', subFolder: 'Incorporation Certificate' },
-      'legalEntityChart': { folder: 'Legal Information', subFolder: 'Legal Entity Chart' },
-      'governmentId': { folder: 'Legal Information', subFolder: 'Government ID' },
-      'w9form': { folder: 'Legal Information', subFolder: 'W9 Form' },
-      
-      // Other
-      'other': { folder: 'Other Documents', subFolder: 'Other' },
-    };
-
-    return folderMapping[fieldName] || { folder: 'Other Documents', subFolder: 'Uncategorized' };
-  };
-
   // Fonction pour envoyer un fichier individuel
   const sendFile = async (file: File, fieldName: string, fileInfo: any, companyName?: string): Promise<FileUploadResult> => {
     try {
@@ -218,8 +194,7 @@ export const useFileUpload = () => {
         };
       }
 
-      // Récupérer les informations de dossier Google Drive
-      const { folder, subFolder } = getGoogleDriveFolders(fieldName);
+      const label = getUploadLabelForField(fieldName);
 
       // Récupérer les IDs HubSpot depuis les variables d'environnement
       const webhookFilesUrl = process.env.REACT_APP_WEBHOOK_URL_FILES;
@@ -243,8 +218,7 @@ export const useFileUpload = () => {
       const formData = new FormData();
       formData.append('file', file);
       formData.append('fieldName', fieldName);
-      formData.append('folder', folder);
-      formData.append('subFolder', subFolder);
+      formData.append('label', label);
       formData.append('companyName', companyName ?? '');
 
       

--- a/src/hooks/useFormValidation.ts
+++ b/src/hooks/useFormValidation.ts
@@ -1,5 +1,12 @@
 import { useSelector } from 'react-redux';
 import { RootState } from '../store';
+import {
+  validateAccountingSystemFields,
+  validatePaymentProcessorFields,
+  getDiligenceFileCount,
+  validateFinancialDocumentUploads,
+  validateUnderwritingUploadFields,
+} from '../utils/underwritingFields';
 
 export const useFormValidation = () => {
   const formData = useSelector((state: RootState) => state.form);
@@ -98,27 +105,46 @@ export const useFormValidation = () => {
     const errors: { [key: string]: string } = {};
 
     // Ticketing Information files
-    if (diligenceInfo.ticketingCompanyReport.files.length === 0) {
+    if (getDiligenceFileCount(diligenceInfo.ticketingCompanyReport) === 0) {
       errors.ticketingCompanyReport = 'Ticketing company report is required';
     }
-    if (formData.formData.ticketingInfo.paymentProcessing === 'Venue' && diligenceInfo.ticketingServiceAgreement.files.length === 0) {
+    if (
+      formData.formData.ticketingInfo.paymentProcessing === 'Venue' &&
+      getDiligenceFileCount(diligenceInfo.ticketingServiceAgreement) === 0
+    ) {
       errors.ticketingServiceAgreement = 'Ticketing service agreement is required';
     }
 
-    // Financial Information files
-    if (diligenceInfo.financialStatements.files.length === 0) {
-      errors.financialStatements = 'Financial statements are required';
-    }
-
     // Legal Information files
-    if (diligenceInfo.incorporationCertificate.files.length === 0) {
+    if (getDiligenceFileCount(diligenceInfo.incorporationCertificate) === 0) {
       errors.incorporationCertificate = 'Incorporation certificate is required';
     }
-    if (!financesInfo.singleEntity && diligenceInfo.legalEntityChart.files.length === 0) {
+    if (
+      !financesInfo.singleEntity &&
+      getDiligenceFileCount(diligenceInfo.legalEntityChart) === 0
+    ) {
       errors.legalEntityChart = 'Legal entity chart is required';
     }
 
-    // Additional Information validation is now handled in step 3
+    Object.assign(
+      errors,
+      validateFinancialDocumentUploads({
+        financialsYtdPL: diligenceInfo.financialsYtdPL,
+        financialsYtdBS: diligenceInfo.financialsYtdBS,
+        financialsYear1PL: diligenceInfo.financialsYear1PL,
+        financialsYear1BS: diligenceInfo.financialsYear1BS,
+        financialsYear2PL: diligenceInfo.financialsYear2PL,
+        financialsYear2BS: diligenceInfo.financialsYear2BS,
+      })
+    );
+
+    Object.assign(
+      errors,
+      validateUnderwritingUploadFields({
+        futureEventSchedule: diligenceInfo.futureEventSchedule,
+        venueAgreements: diligenceInfo.venueAgreements,
+      })
+    );
 
     return { isValid: Object.keys(errors).length === 0, errors };
   };
@@ -137,7 +163,7 @@ export const useFormValidation = () => {
     const companyValidation = validateCompanyInfo();
     
     // Add ticketing validation for step 1
-    const { ticketingInfo, volumeInfo } = formData.formData;
+    const { ticketingInfo, volumeInfo, financesInfo } = formData.formData;
     const ticketingErrors: { [key: string]: string } = {};
     
     if (!ticketingInfo.paymentProcessing) ticketingErrors.paymentProcessing = 'Payment processing is required';
@@ -146,6 +172,16 @@ export const useFormValidation = () => {
     if (!ticketingInfo.settlementPayout) ticketingErrors.settlementPayout = 'Settlement payout policy is required';
     if (volumeInfo.nextYearEvents <= 0) ticketingErrors.nextYearEvents = 'Number of events must be greater than 0';
     if (volumeInfo.nextYearSales <= 0) ticketingErrors.nextYearSales = 'Gross annual ticketing volume must be greater than 0';
+
+    Object.assign(ticketingErrors, validatePaymentProcessorFields({
+      paymentProcessor: ticketingInfo.paymentProcessor,
+      otherPaymentProcessor: ticketingInfo.otherPaymentProcessor,
+    }));
+
+    Object.assign(ticketingErrors, validateAccountingSystemFields({
+      accountingSystem: financesInfo.accountingSystem,
+      otherAccountingSystem: financesInfo.otherAccountingSystem,
+    }));
     
     return {
       isValid: personalValidation.isValid && companyValidation.isValid && Object.keys(ticketingErrors).length === 0,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,8 @@ import ProtectedRoute from './components/ProtectedRoute';
 import reportWebVitals from './reportWebVitals';
 import SubmitSuccess from './components/SubmitSuccess';
 
+const isDevelopment = process.env.NODE_ENV === 'development';
+
 Sentry.init({
   dsn: 'https://c5bcc114d568abceb81c07f53de7d301@o4510828693422080.ingest.us.sentry.io/4510828695388160',
   sendDefaultPii: true,
@@ -22,11 +24,11 @@ Sentry.init({
     }),
   ],
   // Tracing
-  tracesSampleRate: 0.05,
+  tracesSampleRate: isDevelopment ? 1.0 : 0.05,
   // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
   tracePropagationTargets: ['localhost', /^https:\/\/yourserver\.io\/api/],
-  // Session Replay
-  replaysSessionSampleRate: 0.1,
+  // Session Replay — 100% in local dev for ticket validation
+  replaysSessionSampleRate: isDevelopment ? 1.0 : 0.1,
   replaysOnErrorSampleRate: 1.0,
 });
 

--- a/src/store/form/formSlice.ts
+++ b/src/store/form/formSlice.ts
@@ -1,7 +1,63 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { initialState } from './initialFormState';
 import { loadApplication, saveApplication, submitApplication } from './formThunks';
-import { FormState } from './formTypes';
+import { FormState, DiligenceFileData } from './formTypes';
+
+const mergeDiligenceInfo = (
+  saved?: Partial<FormState['diligenceInfo']>
+): FormState['diligenceInfo'] => {
+  const base = initialState.diligenceInfo;
+  return (Object.keys(base) as Array<keyof FormState['diligenceInfo']>).reduce(
+    (merged, key) => {
+      const savedField = saved?.[key];
+      merged[key] = {
+        files: savedField?.files ?? [],
+        fileInfos: savedField?.fileInfos ?? [],
+      };
+      return merged;
+    },
+    {} as Record<keyof FormState['diligenceInfo'], DiligenceFileData>
+  ) as FormState['diligenceInfo'];
+};
+
+const hydrateFormState = (saved: Partial<FormState>): FormState => ({
+  ...initialState,
+  ...saved,
+  formData: {
+    ...initialState.formData,
+    ...saved.formData,
+    personalInfo: {
+      ...initialState.formData.personalInfo,
+      ...saved.formData?.personalInfo,
+    },
+    companyInfo: {
+      ...initialState.formData.companyInfo,
+      ...saved.formData?.companyInfo,
+    },
+    ticketingInfo: {
+      ...initialState.formData.ticketingInfo,
+      ...saved.formData?.ticketingInfo,
+    },
+    volumeInfo: {
+      ...initialState.formData.volumeInfo,
+      ...saved.formData?.volumeInfo,
+    },
+    fundsInfo: {
+      ...initialState.formData.fundsInfo,
+      ...saved.formData?.fundsInfo,
+    },
+    ownershipInfo: {
+      ...initialState.formData.ownershipInfo,
+      ...saved.formData?.ownershipInfo,
+    },
+    financesInfo: {
+      ...initialState.formData.financesInfo,
+      ...saved.formData?.financesInfo,
+    },
+  },
+  diligenceInfo: mergeDiligenceInfo(saved.diligenceInfo),
+  isSubmitted: false,
+});
 
 // Fonction pour sauvegarder dans le localStorage
 const saveToLocalStorage = (state: FormState) => {
@@ -33,11 +89,7 @@ const formSlice = createSlice({
     // Essayer de charger les données sauvegardées au démarrage
     const savedData = loadFromLocalStorage();
     if (savedData) {
-      return {
-        ...initialState,
-        ...savedData,
-        isSubmitted: false // Toujours false au démarrage, seul le backend détermine
-      };
+      return hydrateFormState(savedData);
     }
     
     return initialState;
@@ -76,16 +128,19 @@ const formSlice = createSlice({
       saveToLocalStorage(state);
     },
     updateDiligenceInfo: (state, action: PayloadAction<Partial<FormState['diligenceInfo']>>) => {
-      state.diligenceInfo = { ...state.diligenceInfo, ...action.payload };
+      state.diligenceInfo = mergeDiligenceInfo({
+        ...state.diligenceInfo,
+        ...action.payload,
+      });
       saveToLocalStorage(state);
     },
     loadSavedApplication: (state, action) => {
-      const newState = {
+      const newState = hydrateFormState({
         ...state,
         currentStep: action.payload.currentStep || 0,
-        formData: action.payload.formData || initialState.formData,
-        diligenceInfo: action.payload.diligenceInfo || initialState.diligenceInfo
-      };
+        formData: action.payload.formData,
+        diligenceInfo: action.payload.diligenceInfo,
+      });
       saveToLocalStorage(newState);
       return newState;
     },
@@ -105,12 +160,12 @@ const formSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(loadApplication.fulfilled, (state, action) => {
-        const newState = {
+        const newState = hydrateFormState({
           ...state,
           currentStep: action.payload.currentStep || 1,
-          formData: action.payload.formData || initialState.formData,
-          diligenceInfo: action.payload.diligenceInfo || initialState.diligenceInfo
-        };
+          formData: action.payload.formData,
+          diligenceInfo: action.payload.diligenceInfo,
+        });
         saveToLocalStorage(newState);
         return newState;
       })

--- a/src/store/form/formTypes.ts
+++ b/src/store/form/formTypes.ts
@@ -64,7 +64,9 @@ export interface Address {
         currentPartner: string;
         otherPartner: string;
         settlementPayout: string;
-        paymentProcessing: string;  
+        paymentProcessing: string;
+        paymentProcessor: string;
+        otherPaymentProcessor: string;
       };
       volumeInfo: {
         nextYearEvents: number;
@@ -96,13 +98,14 @@ export interface Address {
         ownershipChanged: boolean;
         industryReferences: string;
         additionalComments: string;
+        accountingSystem: string;
+        otherAccountingSystem: string;
       };
     };
   
     diligenceInfo: {
       ticketingCompanyReport: DiligenceFileData;
       ticketingServiceAgreement: DiligenceFileData;
-      financialStatements: DiligenceFileData;
       bankStatement: DiligenceFileData;
       incorporationCertificate: DiligenceFileData;
       legalEntityChart: DiligenceFileData;
@@ -110,6 +113,14 @@ export interface Address {
       w9form: DiligenceFileData;
       lastYearTaxes: DiligenceFileData;
       other: DiligenceFileData;
+      futureEventSchedule: DiligenceFileData;
+      financialsYtdPL: DiligenceFileData;
+      financialsYtdBS: DiligenceFileData;
+      financialsYear1PL: DiligenceFileData;
+      financialsYear1BS: DiligenceFileData;
+      financialsYear2PL: DiligenceFileData;
+      financialsYear2BS: DiligenceFileData;
+      venueAgreements: DiligenceFileData;
     };
   }
   

--- a/src/store/form/hubspotLists.ts
+++ b/src/store/form/hubspotLists.ts
@@ -145,6 +145,22 @@ export const clientType = {
     'Venue':'The Venue (e.g. MSG)',
     'It varies':'It varies'
   };
+
+  export const paymentProcessorOptions = {
+    'Stripe': 'Stripe',
+    'PayPal': 'PayPal',
+    'Square': 'Square',
+    'Adyen': 'Adyen',
+    'Other': 'Other',
+  };
+
+  export const accountingSystemOptions = {
+    'QuickBooks': 'QuickBooks',
+    'Xero': 'Xero',
+    'NetSuite': 'NetSuite',
+    'Excel': 'Excel',
+    'Other': 'Other',
+  };
   export const precision = [
     'The Ticketing Co is the merchant of record',
     'From the Payment Processor (e.g. Stripe) We are the merchant of record',

--- a/src/store/form/initialFormState.ts
+++ b/src/store/form/initialFormState.ts
@@ -12,7 +12,14 @@ export const initialState: FormState = {
       businessType: '', companyAddressDisplay: '', companyAddress: '', companyZipcode: '', companyState: '', companyCountry: '', companyCity: '',
       ein: '', stateOfIncorporation: '', memberOf: ''
     },
-    ticketingInfo: { currentPartner: '', otherPartner: '', settlementPayout: '', paymentProcessing: '' },
+    ticketingInfo: {
+      currentPartner: '',
+      otherPartner: '',
+      settlementPayout: '',
+      paymentProcessing: '',
+      paymentProcessor: '',
+      otherPaymentProcessor: '',
+    },
     volumeInfo: {
       nextYearEvents: 0, nextYearSales: 0,
     },
@@ -29,13 +36,14 @@ export const initialState: FormState = {
       hasBankruptcy: false, ownershipChanged: false, hasTicketingDebt: false,
       industryReferences: '',
       additionalComments: '',
+      accountingSystem: '',
+      otherAccountingSystem: '',
     },
   },
 
   diligenceInfo: {
     ticketingCompanyReport: { files: [], fileInfos: [] },
     ticketingServiceAgreement: { files: [], fileInfos: [] },
-    financialStatements: { files: [], fileInfos: [] },
     bankStatement: { files: [], fileInfos: [] },
     incorporationCertificate: { files: [], fileInfos: [] },
     legalEntityChart: { files: [], fileInfos: [] },
@@ -43,5 +51,13 @@ export const initialState: FormState = {
     w9form: { files: [], fileInfos: [] },
     lastYearTaxes: { files: [], fileInfos: [] },
     other: { files: [], fileInfos: [] },
+    futureEventSchedule: { files: [], fileInfos: [] },
+    financialsYtdPL: { files: [], fileInfos: [] },
+    financialsYtdBS: { files: [], fileInfos: [] },
+    financialsYear1PL: { files: [], fileInfos: [] },
+    financialsYear1BS: { files: [], fileInfos: [] },
+    financialsYear2PL: { files: [], fileInfos: [] },
+    financialsYear2BS: { files: [], fileInfos: [] },
+    venueAgreements: { files: [], fileInfos: [] },
   }
 };

--- a/src/utils/underwritingFields.test.ts
+++ b/src/utils/underwritingFields.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import {
   buildUnderwritingWebhookCompanyFields,
   FINANCIAL_DOCUMENT_UPLOAD_KEYS,

--- a/src/utils/underwritingFields.test.ts
+++ b/src/utils/underwritingFields.test.ts
@@ -1,0 +1,215 @@
+import {
+  buildUnderwritingWebhookCompanyFields,
+  FINANCIAL_DOCUMENT_UPLOAD_KEYS,
+  getDiligenceFileCount,
+  getUploadLabelForField,
+  UPLOAD_LABELS,
+  validateAccountingSystemFields,
+  validateFinancialDocumentUploads,
+  validatePaymentProcessorFields,
+  validateUnderwritingUploadFields,
+} from './underwritingFields';
+
+// ─── getUploadLabelForField ───────────────────────────────────────────────────
+
+describe('getUploadLabelForField', () => {
+  it('maps ticketing uploads to the ticketing label', () => {
+    for (const field of ['ticketingCompanyReport', 'ticketingServiceAgreement', 'futureEventSchedule', 'venueAgreements']) {
+      expect(getUploadLabelForField(field)).toBe(UPLOAD_LABELS.TICKETING);
+    }
+  });
+
+  it('maps every financial document upload to the financial label', () => {
+    for (const key of FINANCIAL_DOCUMENT_UPLOAD_KEYS) {
+      expect(getUploadLabelForField(key)).toBe(UPLOAD_LABELS.FINANCIAL);
+    }
+  });
+
+  it('maps bank statement to the bank label', () => {
+    expect(getUploadLabelForField('bankStatement')).toBe(UPLOAD_LABELS.BANK);
+  });
+
+  it('maps kyb documents to the kyb label', () => {
+    for (const field of ['incorporationCertificate', 'legalEntityChart', 'governmentId', 'w9form', 'other']) {
+      expect(getUploadLabelForField(field)).toBe(UPLOAD_LABELS.KYB);
+    }
+  });
+
+  it('falls back to kyb for unknown field names', () => {
+    expect(getUploadLabelForField('somethingUnknown')).toBe(UPLOAD_LABELS.KYB);
+  });
+});
+
+// ─── getDiligenceFileCount ────────────────────────────────────────────────────
+
+describe('getDiligenceFileCount', () => {
+  it('returns 0 for undefined (field missing from persisted state)', () => {
+    expect(getDiligenceFileCount(undefined)).toBe(0);
+  });
+
+  it('returns 0 when files array is absent', () => {
+    expect(getDiligenceFileCount({})).toBe(0);
+  });
+
+  it('returns the correct count when files are present', () => {
+    const file = new File(['x'], 'test.pdf');
+    expect(getDiligenceFileCount({ files: [file, file] })).toBe(2);
+  });
+});
+
+// ─── validateFinancialDocumentUploads ────────────────────────────────────────
+
+describe('validateFinancialDocumentUploads', () => {
+  it('does not throw when the whole diligenceInfo object is missing fields (hydration gap)', () => {
+    expect(() => validateFinancialDocumentUploads({})).not.toThrow();
+  });
+
+  it('returns one error per missing financial document', () => {
+    const errors = validateFinancialDocumentUploads({});
+    expect(Object.keys(errors)).toHaveLength(FINANCIAL_DOCUMENT_UPLOAD_KEYS.length);
+  });
+
+  it('returns no errors when every field has at least one file', () => {
+    const file = new File(['x'], 'p&l.pdf');
+    const diligenceInfo = Object.fromEntries(
+      FINANCIAL_DOCUMENT_UPLOAD_KEYS.map((key) => [key, { files: [file] }])
+    ) as Record<(typeof FINANCIAL_DOCUMENT_UPLOAD_KEYS)[number], { files: File[] }>;
+    expect(validateFinancialDocumentUploads(diligenceInfo)).toEqual({});
+  });
+
+  it('reports the correct label in the error message', () => {
+    const errors = validateFinancialDocumentUploads({
+      financialsYtdPL: { files: [] },
+    });
+    expect(errors.financialsYtdPL).toMatch(/Year To Date.*P&L/i);
+  });
+});
+
+// ─── validateUnderwritingUploadFields ────────────────────────────────────────
+
+describe('validateUnderwritingUploadFields', () => {
+  it('requires future event schedule when absent', () => {
+    const errors = validateUnderwritingUploadFields({
+      futureEventSchedule: { files: [] },
+      venueAgreements: { files: [new File(['x'], 'v.pdf')] },
+    });
+    expect(errors).toMatchObject({ futureEventSchedule: expect.any(String) });
+    expect(errors.venueAgreements).toBeUndefined();
+  });
+
+  it('requires venue agreements when absent', () => {
+    const errors = validateUnderwritingUploadFields({
+      futureEventSchedule: { files: [new File(['x'], 'f.pdf')] },
+      venueAgreements: { files: [] },
+    });
+    expect(errors).toMatchObject({ venueAgreements: expect.any(String) });
+    expect(errors.futureEventSchedule).toBeUndefined();
+  });
+
+  it('returns no errors when both fields have files', () => {
+    const file = new File(['x'], 'doc.pdf');
+    expect(
+      validateUnderwritingUploadFields({
+        futureEventSchedule: { files: [file] },
+        venueAgreements: { files: [file] },
+      })
+    ).toEqual({});
+  });
+
+  it('does not throw when called with an empty object', () => {
+    expect(() => validateUnderwritingUploadFields({})).not.toThrow();
+  });
+});
+
+// ─── validatePaymentProcessorFields ──────────────────────────────────────────
+
+describe('validatePaymentProcessorFields', () => {
+  it('requires a selection', () => {
+    const errors = validatePaymentProcessorFields({ paymentProcessor: '', otherPaymentProcessor: '' });
+    expect(errors.paymentProcessor).toBeDefined();
+  });
+
+  it('requires free-text when Other is selected', () => {
+    const errors = validatePaymentProcessorFields({ paymentProcessor: 'Other', otherPaymentProcessor: '' });
+    expect(errors.otherPaymentProcessor).toBeDefined();
+    expect(errors.paymentProcessor).toBeUndefined();
+  });
+
+  it('passes for a known processor', () => {
+    const errors = validatePaymentProcessorFields({ paymentProcessor: 'Stripe', otherPaymentProcessor: '' });
+    expect(errors).toEqual({});
+  });
+
+  it('passes for Other with free text filled', () => {
+    const errors = validatePaymentProcessorFields({ paymentProcessor: 'Other', otherPaymentProcessor: 'MyPay' });
+    expect(errors).toEqual({});
+  });
+});
+
+// ─── validateAccountingSystemFields ──────────────────────────────────────────
+
+describe('validateAccountingSystemFields', () => {
+  it('requires a selection', () => {
+    const errors = validateAccountingSystemFields({ accountingSystem: '', otherAccountingSystem: '' });
+    expect(errors.accountingSystem).toBeDefined();
+  });
+
+  it('requires free-text when Other is selected', () => {
+    const errors = validateAccountingSystemFields({ accountingSystem: 'Other', otherAccountingSystem: '' });
+    expect(errors.otherAccountingSystem).toBeDefined();
+    expect(errors.accountingSystem).toBeUndefined();
+  });
+
+  it('passes for a known system', () => {
+    const errors = validateAccountingSystemFields({ accountingSystem: 'QuickBooks', otherAccountingSystem: '' });
+    expect(errors).toEqual({});
+  });
+});
+
+// ─── buildUnderwritingWebhookCompanyFields ────────────────────────────────────
+
+describe('buildUnderwritingWebhookCompanyFields', () => {
+  it('includes both dropdown values in the submit payload', () => {
+    expect(
+      buildUnderwritingWebhookCompanyFields(
+        { paymentProcessor: 'Stripe', otherPaymentProcessor: '' },
+        { accountingSystem: 'QuickBooks', otherAccountingSystem: '' }
+      )
+    ).toEqual({
+      paymentProcessor: 'Stripe',
+      otherPaymentProcessor: '',
+      accountingSystem: 'QuickBooks',
+      otherAccountingSystem: '',
+    });
+  });
+
+  it('includes free-text when Other is selected for both fields', () => {
+    expect(
+      buildUnderwritingWebhookCompanyFields(
+        { paymentProcessor: 'Other', otherPaymentProcessor: 'CustomPay' },
+        { accountingSystem: 'Other', otherAccountingSystem: 'Google Sheets' }
+      )
+    ).toEqual({
+      paymentProcessor: 'Other',
+      otherPaymentProcessor: 'CustomPay',
+      accountingSystem: 'Other',
+      otherAccountingSystem: 'Google Sheets',
+    });
+  });
+
+  it('clears otherPaymentProcessor when processor is not Other', () => {
+    const result = buildUnderwritingWebhookCompanyFields(
+      { paymentProcessor: 'Adyen', otherPaymentProcessor: 'leftover' },
+      { accountingSystem: 'Xero', otherAccountingSystem: '' }
+    );
+    expect(result.otherPaymentProcessor).toBe('');
+  });
+
+  it('clears otherAccountingSystem when system is not Other', () => {
+    const result = buildUnderwritingWebhookCompanyFields(
+      { paymentProcessor: 'Square', otherPaymentProcessor: '' },
+      { accountingSystem: 'NetSuite', otherAccountingSystem: 'leftover' }
+    );
+    expect(result.otherAccountingSystem).toBe('');
+  });
+});

--- a/src/utils/underwritingFields.ts
+++ b/src/utils/underwritingFields.ts
@@ -1,0 +1,164 @@
+export const UPLOAD_LABELS = {
+  TICKETING: 'ticketing',
+  FINANCIAL: 'financial',
+  BANK: 'bank',
+  KYB: 'kyb',
+} as const;
+
+export type UploadLabel = (typeof UPLOAD_LABELS)[keyof typeof UPLOAD_LABELS];
+
+export const FINANCIAL_DOCUMENT_UPLOAD_KEYS = [
+  'financialsYtdPL',
+  'financialsYtdBS',
+  'financialsYear1PL',
+  'financialsYear1BS',
+  'financialsYear2PL',
+  'financialsYear2BS',
+] as const;
+
+export type FinancialDocumentUploadKey = (typeof FINANCIAL_DOCUMENT_UPLOAD_KEYS)[number];
+
+export const DILIGENCE_UPLOAD_FIELD_KEYS = [
+  'futureEventSchedule',
+  ...FINANCIAL_DOCUMENT_UPLOAD_KEYS,
+  'venueAgreements',
+] as const;
+
+export type DiligenceUploadFieldKey = (typeof DILIGENCE_UPLOAD_FIELD_KEYS)[number];
+
+export const PAYMENT_PROCESSOR_OTHER = 'Other';
+export const ACCOUNTING_SYSTEM_OTHER = 'Other';
+
+const FINANCIAL_DOCUMENT_LABELS: Record<FinancialDocumentUploadKey, string> = {
+  financialsYtdPL: 'Year To Date — P&L',
+  financialsYtdBS: 'Year To Date — Balance Sheet',
+  financialsYear1PL: 'Year - 1 — P&L',
+  financialsYear1BS: 'Year - 1 — Balance Sheet',
+  financialsYear2PL: 'Year - 2 — P&L',
+  financialsYear2BS: 'Year - 2 — Balance Sheet',
+};
+
+const uploadLabelByFieldName: Record<string, UploadLabel> = {
+  // ticketing
+  ticketingCompanyReport: UPLOAD_LABELS.TICKETING,
+  ticketingServiceAgreement: UPLOAD_LABELS.TICKETING,
+  futureEventSchedule: UPLOAD_LABELS.TICKETING,
+  venueAgreements: UPLOAD_LABELS.TICKETING,
+
+  // financial
+  ...Object.fromEntries(
+    FINANCIAL_DOCUMENT_UPLOAD_KEYS.map((key) => [key, UPLOAD_LABELS.FINANCIAL])
+  ),
+  lastYearTaxes: UPLOAD_LABELS.FINANCIAL,
+
+  // bank
+  bankStatement: UPLOAD_LABELS.BANK,
+
+  // kyb
+  incorporationCertificate: UPLOAD_LABELS.KYB,
+  legalEntityChart: UPLOAD_LABELS.KYB,
+  governmentId: UPLOAD_LABELS.KYB,
+  w9form: UPLOAD_LABELS.KYB,
+  other: UPLOAD_LABELS.KYB,
+};
+
+export function getUploadLabelForField(fieldName: string): UploadLabel {
+  return uploadLabelByFieldName[fieldName] ?? UPLOAD_LABELS.KYB;
+}
+
+export interface TicketingUnderwritingFields {
+  paymentProcessor: string;
+  otherPaymentProcessor: string;
+}
+
+export interface FinancesUnderwritingFields {
+  accountingSystem: string;
+  otherAccountingSystem: string;
+}
+
+export function buildUnderwritingWebhookCompanyFields(
+  ticketing: TicketingUnderwritingFields,
+  finances: FinancesUnderwritingFields
+) {
+  return {
+    paymentProcessor: ticketing.paymentProcessor,
+    otherPaymentProcessor:
+      ticketing.paymentProcessor === PAYMENT_PROCESSOR_OTHER
+        ? ticketing.otherPaymentProcessor
+        : '',
+    accountingSystem: finances.accountingSystem,
+    otherAccountingSystem:
+      finances.accountingSystem === ACCOUNTING_SYSTEM_OTHER
+        ? finances.otherAccountingSystem
+        : '',
+  };
+}
+
+export function validatePaymentProcessorFields(
+  ticketing: TicketingUnderwritingFields
+): { [key: string]: string } {
+  const errors: { [key: string]: string } = {};
+  if (!ticketing.paymentProcessor.trim()) {
+    errors.paymentProcessor = 'Payment processor is required';
+  }
+  if (
+    ticketing.paymentProcessor === PAYMENT_PROCESSOR_OTHER &&
+    !ticketing.otherPaymentProcessor.trim()
+  ) {
+    errors.otherPaymentProcessor = 'Please specify your payment processor';
+  }
+  return errors;
+}
+
+export function validateAccountingSystemFields(
+  finances: FinancesUnderwritingFields
+): { [key: string]: string } {
+  const errors: { [key: string]: string } = {};
+  if (!finances.accountingSystem.trim()) {
+    errors.accountingSystem = 'Accounting system is required';
+  }
+  if (
+    finances.accountingSystem === ACCOUNTING_SYSTEM_OTHER &&
+    !finances.otherAccountingSystem.trim()
+  ) {
+    errors.otherAccountingSystem = 'Please specify your accounting system';
+  }
+  return errors;
+}
+
+export function getDiligenceFileCount(
+  field: { files?: File[] } | undefined
+): number {
+  return field?.files?.length ?? 0;
+}
+
+export function validateFinancialDocumentUploads(
+  diligenceInfo: Partial<Record<FinancialDocumentUploadKey, { files?: File[] }>>
+): { [key: string]: string } {
+  const errors: { [key: string]: string } = {};
+
+  for (const key of FINANCIAL_DOCUMENT_UPLOAD_KEYS) {
+    if (getDiligenceFileCount(diligenceInfo[key]) === 0) {
+      errors[key] = `${FINANCIAL_DOCUMENT_LABELS[key]} is required`;
+    }
+  }
+
+  return errors;
+}
+
+export function validateUnderwritingUploadFields(
+  diligenceInfo: Partial<
+    Pick<Record<DiligenceUploadFieldKey, { files?: File[] }>, 'futureEventSchedule' | 'venueAgreements'>
+  >
+): { [key: string]: string } {
+  const errors: { [key: string]: string } = {};
+
+  if (getDiligenceFileCount(diligenceInfo.futureEventSchedule) === 0) {
+    errors.futureEventSchedule = 'Future event schedule is required';
+  }
+  if (getDiligenceFileCount(diligenceInfo.venueAgreements) === 0) {
+    errors.venueAgreements = 'Venue agreements are required';
+  }
+
+  return errors;
+}

--- a/tests/prod-form-critical-path.spec.ts
+++ b/tests/prod-form-critical-path.spec.ts
@@ -1,6 +1,29 @@
 import path from "node:path";
 import { expect, test } from "@playwright/test";
 
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+/** All upload selectors that must be filled in step 4. */
+const REQUIRED_UPLOAD_SELECTORS = [
+  // 1. Ticketing
+  "#file-upload-ticketingCompanyReport",
+  "#file-upload-futureEventSchedule",
+  "#file-upload-venueAgreements",
+
+  // 2. Finance – one file per document field
+  "#file-upload-financialsYtdPL",
+  "#file-upload-financialsYtdBS",
+  "#file-upload-financialsYear1PL",
+  "#file-upload-financialsYear1BS",
+  "#file-upload-financialsYear2PL",
+  "#file-upload-financialsYear2BS",
+
+  // 3. Legal
+  "#file-upload-incorporationCertificate",
+] as const;
+
+// ─── main test ───────────────────────────────────────────────────────────────
+
 test("prod form critical path stays healthy", async ({ page }) => {
   const now = Date.now();
   const tag = `E2E_PROD_${now}`;
@@ -10,72 +33,100 @@ test("prod form critical path stays healthy", async ({ page }) => {
   const failedCriticalRequests: string[] = [];
   const badCriticalResponses: Array<{ url: string; status: number }> = [];
 
-  const isCriticalUrl = (url: string) => /(make\.com|\/applications\/|webhook|upload)/i.test(url);
+  const isCriticalUrl = (url: string) =>
+    /(make\.com|\/applications\/|webhook|upload)/i.test(url);
 
   page.on("requestfailed", (request) => {
     if (isCriticalUrl(request.url())) {
-      failedCriticalRequests.push(`${request.method()} ${request.url()} :: ${request.failure()?.errorText ?? "failed"}`);
+      failedCriticalRequests.push(
+        `${request.method()} ${request.url()} :: ${request.failure()?.errorText ?? "failed"}`
+      );
     }
   });
 
   page.on("response", (response) => {
     const url = response.url();
-    const method = response.request().method();
     const status = response.status();
-    if (method === "POST" && isCriticalUrl(url) && status >= 400) {
+    if (response.request().method() === "POST" && isCriticalUrl(url) && status >= 400) {
       badCriticalResponses.push({ url, status });
     }
   });
 
-  await page.goto("/form", { waitUntil: "domcontentloaded" });
+  // ── Step 1 — Tell us about your business ──────────────────────────────────
 
+  await page.goto("/form", { waitUntil: "domcontentloaded" });
   await expect(page.getByRole("heading", { name: "Tell us about your business" })).toBeVisible();
 
+  // Verify Next is blocked when required fields are empty
   await page.getByRole("button", { name: "Next" }).click();
   await expect(page.getByText("Please enter a valid phone number")).toBeVisible();
 
+  // Personal info
   await page.locator('input[name="firstname"]').fill("E2E");
   await page.locator('input[name="lastname"]').fill("Prod");
   await page.locator('input[name="email"]').fill(email);
   await page.locator('input[name="phone"]').fill("4155552671");
 
+  // Company info
   await page.locator('input[name="name"]').fill(tag);
   await page.locator('input[name="role"]').fill("Owner");
   await page.locator('select[name="clientType"]').selectOption("Promoter");
   await page.locator('select[name="yearsInBusiness"]').selectOption("2-5 years");
   await page.locator('input[name="socials"]').fill("https://example.com");
   await page.locator('select[name="memberOf"]').selectOption("None");
+
+  // Ticketing info (now on step 1)
   await page.locator('input[name="nextYearEvents"]').fill("12");
   await page.locator('input[name="nextYearSales"]').fill("250000");
   await page.locator('select[name="paymentProcessing"]').selectOption("Ticketing Co");
   await page.locator('select[name="currentPartner"]').selectOption("Eventbrite");
   await page.locator('select[name="settlementPayout"]').selectOption("Weekly");
 
-  await page.getByRole("button", { name: "Next" }).click();
-  await expect(page.locator('select[name="timingOfFunding"]')).toBeVisible();
+  // New dropdowns added in this feature branch (step 1)
+  await page.locator('select[name="paymentProcessor"]').selectOption("Stripe");
+  await page.locator('select[name="accountingSystem"]').selectOption("QuickBooks");
 
+  await page.getByRole("button", { name: "Next" }).click();
+
+  // ── Step 2 — Get funding ──────────────────────────────────────────────────
+
+  await expect(page.locator('select[name="timingOfFunding"]')).toBeVisible();
   await page.locator('select[name="timingOfFunding"]').selectOption("In the next month");
   await page.locator('select[name="useOfProceeds"]').selectOption("General Working Capital Needs");
 
   await page.getByRole("button", { name: "Next" }).click();
+
+  // ── Step 3 — Business & Ownership ─────────────────────────────────────────
+
   await expect(page.locator('input[name="legalEntityName"]')).toBeVisible();
 
   await page.locator('input[name="legalEntityName"]').fill(`${tag} LLC`);
   await page.locator('input[name="dba"]').fill(tag);
   await page.locator('select[name="businessType"]').selectOption("Limited Liability Company (LLC)");
   await page.locator('select[name="stateOfIncorporation"]').selectOption("CA");
-  await page.locator('input[name="companyAddressDisplay"]').fill("123 Market St, San Francisco, CA 94105, USA");
+  await page.locator('input[name="companyAddressDisplay"]').fill(
+    "123 Market St, San Francisco, CA 94105, USA"
+  );
   await page.locator('input[name="ein"]').fill("12-3456789");
   await page.locator('input[name="owner0Name"]').fill("Jane Owner");
   await page.locator('input[name="owner0Percentage"]').fill("100");
-  await page.locator('input[name="owner0Address"]').fill("123 Main St, San Francisco, CA 94105, USA");
+  await page.locator('input[name="owner0Address"]').fill(
+    "123 Main St, San Francisco, CA 94105, USA"
+  );
   await page.locator('input[name="owner0BirthDate"]').fill("1988-01-01");
   await page.locator('textarea[name="industryReferences"]').fill(`Reference for ${tag}`);
-  await page.locator('textarea[name="additionalComments"]').fill(`Automated E2E production run ${tag}`);
+  await page.locator('textarea[name="additionalComments"]').fill(
+    `Automated E2E production run ${tag}`
+  );
 
   await page.getByRole("button", { name: "Next" }).click();
+
+  // ── Step 4 — Diligence Files ──────────────────────────────────────────────
+
+  // Verify at least the first required upload field is visible
   await expect(page.locator("#file-upload-ticketingCompanyReport")).toBeVisible();
 
+  // Helper: trigger a file upload and wait for the Make webhook POST to respond
   const waitForUploadPost = () =>
     page.waitForResponse(
       (response) =>
@@ -84,31 +135,103 @@ test("prod form critical path stays healthy", async ({ page }) => {
       { timeout: 30_000 }
     );
 
-  const uploadResponse1 = waitForUploadPost();
-  await page.locator("#file-upload-ticketingCompanyReport").setInputFiles(fixturePath);
-  const uploadResult1 = await uploadResponse1;
-  expect(uploadResult1.status()).toBeLessThan(400);
+  const uploadField = async (selector: string) => {
+    const pending = waitForUploadPost();
+    await page.locator(selector).setInputFiles(fixturePath);
+    const result = await pending;
+    expect(result.status()).toBeLessThan(400);
+  };
 
-  const uploadResponse2 = waitForUploadPost();
-  await page.locator("#file-upload-financialStatements").setInputFiles(fixturePath);
-  const uploadResult2 = await uploadResponse2;
-  expect(uploadResult2.status()).toBeLessThan(400);
+  for (const selector of REQUIRED_UPLOAD_SELECTORS) {
+    await uploadField(selector);
+  }
 
-  const uploadResponse3 = waitForUploadPost();
-  await page.locator("#file-upload-incorporationCertificate").setInputFiles(fixturePath);
-  const uploadResult3 = await uploadResponse3;
-  expect(uploadResult3.status()).toBeLessThan(400);
-
+  // Confirm at least one uploaded filename is visible on the page
   await expect(page.getByText("e2e-upload.csv").first()).toBeVisible();
 
-  await page.getByRole("button", { name: "Next" }).click();
-  await expect(page.getByRole("button", { name: "Submit" })).toBeVisible();
+  // Verify Next button is not disabled while navigating (no submit in flight)
+  const nextButton = page.getByRole("button", { name: "Next" });
+  await expect(nextButton).toBeEnabled();
+  await nextButton.click();
 
-  await page.getByRole("button", { name: "Submit" }).click();
+  // ── Step 5 — Review & Submit ──────────────────────────────────────────────
+
+  const submitButton = page.getByRole("button", { name: "Submit" });
+  await expect(submitButton).toBeVisible();
+  await expect(submitButton).toBeEnabled();
+
+  await submitButton.click();
+
+  // Submit button must become disabled immediately after click (anti double-submit)
+  await expect(submitButton).toBeDisabled();
+
+  // Wait for navigation to success page
   await page.waitForURL("**/submit-success", { timeout: 20_000 });
   await expect(page).toHaveURL(/\/submit-success$/);
   await expect(page.getByText("Application Submitted Successfully")).toBeVisible();
 
+  // No critical HTTP errors or failed requests throughout the whole flow
   expect(failedCriticalRequests, failedCriticalRequests.join("\n")).toEqual([]);
   expect(badCriticalResponses, JSON.stringify(badCriticalResponses, null, 2)).toEqual([]);
+});
+
+// ─── isolated validation tests ───────────────────────────────────────────────
+
+test("step 4: Next is blocked when no files are uploaded", async ({ page }) => {
+  // Navigate through steps 1-3 using the minimum valid data, then verify
+  // that clicking Next on an empty step 4 shows validation errors instead of
+  // advancing to step 5.
+
+  await page.goto("/form", { waitUntil: "domcontentloaded" });
+
+  // Step 1
+  await page.locator('input[name="firstname"]').fill("Test");
+  await page.locator('input[name="lastname"]').fill("User");
+  await page.locator('input[name="email"]').fill("test@example.com");
+  await page.locator('input[name="phone"]').fill("4155552671");
+  await page.locator('input[name="name"]').fill("Test Co");
+  await page.locator('input[name="role"]').fill("Owner");
+  await page.locator('select[name="clientType"]').selectOption("Promoter");
+  await page.locator('select[name="yearsInBusiness"]').selectOption("2-5 years");
+  await page.locator('input[name="socials"]').fill("https://example.com");
+  await page.locator('select[name="memberOf"]').selectOption("None");
+  await page.locator('input[name="nextYearEvents"]').fill("5");
+  await page.locator('input[name="nextYearSales"]').fill("100000");
+  await page.locator('select[name="paymentProcessing"]').selectOption("Ticketing Co");
+  await page.locator('select[name="currentPartner"]').selectOption("Eventbrite");
+  await page.locator('select[name="settlementPayout"]').selectOption("Weekly");
+  await page.locator('select[name="paymentProcessor"]').selectOption("Stripe");
+  await page.locator('select[name="accountingSystem"]').selectOption("QuickBooks");
+  await page.getByRole("button", { name: "Next" }).click();
+
+  // Step 2
+  await expect(page.locator('select[name="timingOfFunding"]')).toBeVisible();
+  await page.locator('select[name="timingOfFunding"]').selectOption("In the next month");
+  await page.locator('select[name="useOfProceeds"]').selectOption("General Working Capital Needs");
+  await page.getByRole("button", { name: "Next" }).click();
+
+  // Step 3
+  await expect(page.locator('input[name="legalEntityName"]')).toBeVisible();
+  await page.locator('input[name="legalEntityName"]').fill("Test Co LLC");
+  await page.locator('input[name="dba"]').fill("Test Co");
+  await page.locator('select[name="businessType"]').selectOption("Limited Liability Company (LLC)");
+  await page.locator('select[name="stateOfIncorporation"]').selectOption("CA");
+  await page.locator('input[name="companyAddressDisplay"]').fill(
+    "123 Market St, San Francisco, CA 94105, USA"
+  );
+  await page.locator('input[name="ein"]').fill("12-3456789");
+  await page.locator('input[name="owner0Name"]').fill("Jane Owner");
+  await page.locator('input[name="owner0Percentage"]').fill("100");
+  await page.locator('input[name="owner0Address"]').fill("123 Main St, San Francisco, CA 94105");
+  await page.locator('input[name="owner0BirthDate"]').fill("1988-01-01");
+  await page.locator('textarea[name="industryReferences"]').fill("Reference person");
+  await page.locator('textarea[name="additionalComments"]').fill("Comments");
+  await page.getByRole("button", { name: "Next" }).click();
+
+  // Step 4 — click Next without uploading anything
+  await expect(page.locator("#file-upload-ticketingCompanyReport")).toBeVisible();
+  await page.getByRole("button", { name: "Next" }).click();
+
+  // Must stay on step 4 (upload fields still visible) and show at least one error
+  await expect(page.locator("#file-upload-ticketingCompanyReport")).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- add underwriting field helpers and migrate diligence uploads to explicit ticketing/financial/bank/kyb label mapping for Make webhook payloads
- update step 1 and step 4 UX/validation (new processor/accounting dropdowns, six financial upload fields, venue agreements in ticketing) and harden form hydration guards
- prevent duplicate submissions in step 5 and refresh automated coverage with underwriting unit tests plus Playwright critical-path checks

## Test plan
- [x] `CI=true npm test`
- [x] `npm run test:e2e:prod`

Made with [Cursor](https://cursor.com)