### PR TITLE
feat: persist companyName from URL param as read-only (#44)

### DIFF
--- a/.github/workflows/playwright-pr.yml
+++ b/.github/workflows/playwright-pr.yml
@@ -21,6 +21,9 @@ jobs:
       REACT_APP_SEND_SUMMARY: ${{ secrets.REACT_APP_SEND_SUMMARY }}
       REACT_APP_PLAID_LINK_TOKEN_URL: ${{ secrets.REACT_APP_PLAID_LINK_TOKEN_URL }}
       REACT_APP_PLAID_WEBHOOK_URL: ${{ secrets.REACT_APP_PLAID_WEBHOOK_URL }}
+      REACT_APP_CHECK_PASSWORD_CUSTOMER_LINK_WEBHOOK: ${{ secrets.REACT_APP_CHECK_PASSWORD_CUSTOMER_LINK_WEBHOOK }}
+      E2E_COMPANY_NAME: ${{ secrets.E2E_COMPANY_NAME }}
+      E2E_COMPANY_PASSWORD: ${{ secrets.E2E_COMPANY_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,8 +40,12 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Run Playwright critical path
+      - name: Run Playwright critical path (generic)
         run: npm run test:e2e:prod
+
+      - name: Run Playwright critical path (custom link)
+        if: ${{ env.E2E_COMPANY_NAME != '' }}
+        run: npm run test:e2e:custom
 
       - name: Upload Playwright artifacts
         if: ${{ always() }}

--- a/__mocks__/axios.js
+++ b/__mocks__/axios.js
@@ -1,0 +1,15 @@
+const axios = {
+  get: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn(),
+  create: jest.fn(() => axios),
+  defaults: { headers: { common: {} } },
+  interceptors: {
+    request: { use: jest.fn(), eject: jest.fn() },
+    response: { use: jest.fn(), eject: jest.fn() },
+  },
+};
+
+module.exports = axios;
+module.exports.default = axios;

--- a/docs/superpowers/plans/2026-05-28-persist-companyname-url-param.md
+++ b/docs/superpowers/plans/2026-05-28-persist-companyname-url-param.md
@@ -1,0 +1,443 @@
+# Persist companyName from URL Param Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a client accesses the form via `?companyName=AcmeCorp`, persist that name into Redux state and lock the Company Name field as read-only, so the name stays consistent throughout the form.
+
+**Architecture:** Add a `companyNameFromUrl` boolean flag to the Redux `FormState`. A `useEffect` in `MultiStepFormContent` reads the URL param on mount and populates `companyInfo.name` + sets the flag. `PasswordProtection` preserves query params through navigation. `CompanyInfo` renders the field as disabled when the flag is set.
+
+**Tech Stack:** React 18, Redux Toolkit, React Router v6, TypeScript
+
+---
+
+### Task 1: Add `companyNameFromUrl` to Redux State
+
+**Files:**
+- Modify: `src/store/form/formTypes.ts:31-35`
+- Modify: `src/store/form/initialFormState.ts:3-8`
+- Modify: `src/store/form/formSlice.ts:86-205`
+
+- [ ] **Step 1: Add the field to `FormState` interface**
+
+In `src/store/form/formTypes.ts`, add `companyNameFromUrl` to the `FormState` interface, right after `isSubmitted`:
+
+```typescript
+export interface FormState {
+    currentStep: number;
+    email: string;
+    emailError: string;
+    isSubmitted: boolean;
+    companyNameFromUrl: boolean;
+    formData: {
+```
+
+- [ ] **Step 2: Set initial value in `initialFormState.ts`**
+
+In `src/store/form/initialFormState.ts`, add `companyNameFromUrl: false` after `isSubmitted`:
+
+```typescript
+export const initialState: FormState = {
+  currentStep: 1,
+  email: '',
+  emailError: '',
+  isSubmitted: false,
+  companyNameFromUrl: false,
+  formData: {
+```
+
+- [ ] **Step 3: Add the reducer to `formSlice.ts`**
+
+In `src/store/form/formSlice.ts`, add a new reducer `setCompanyNameFromUrl` inside the `reducers` object (after `resetSubmitted`):
+
+```typescript
+    setCompanyNameFromUrl: (state, action: PayloadAction<boolean>) => {
+      state.companyNameFromUrl = action.payload;
+      saveToLocalStorage(state);
+    },
+```
+
+- [ ] **Step 4: Export the new action**
+
+In `src/store/form/formSlice.ts`, add `setCompanyNameFromUrl` to the destructured exports:
+
+```typescript
+export const { 
+  setCurrentStep, 
+  updatePersonalInfo, 
+  updateCompanyInfo, 
+  updateTicketingInfo, 
+  updateVolumeInfo, 
+  updateFundsInfo, 
+  updateOwnershipInfo, 
+  updateFinancesInfo,
+  updateBankInfo,
+  updateDiligenceInfo,
+  loadSavedApplication,
+  clearFormData,
+  setSubmitted,
+  resetSubmitted,
+  setCompanyNameFromUrl
+} = formSlice.actions;
+```
+
+- [ ] **Step 5: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors related to `companyNameFromUrl`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/store/form/formTypes.ts src/store/form/initialFormState.ts src/store/form/formSlice.ts
+git commit -m "feat(store): add companyNameFromUrl flag to FormState (#44)"
+```
+
+---
+
+### Task 2: Preserve query params in `PasswordProtection` navigation
+
+**Files:**
+- Modify: `src/components/PasswordProtection.tsx:58`
+
+- [ ] **Step 1: Change navigate call to preserve query params**
+
+In `src/components/PasswordProtection.tsx`, change line 58 from:
+
+```typescript
+        navigate('/form');
+```
+
+to:
+
+```typescript
+        navigate('/form' + window.location.search);
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/PasswordProtection.tsx
+git commit -m "fix(auth): preserve URL query params after password validation (#44)"
+```
+
+---
+
+### Task 3: Add `useEffect` in `MultiStepForm` to read URL param on mount
+
+**Files:**
+- Modify: `src/components/MultiStepForm.tsx:1-6,26-55`
+
+- [ ] **Step 1: Add imports**
+
+In `src/components/MultiStepForm.tsx`, add the new imports. Change line 5 from:
+
+```typescript
+import {   setSubmitted } from '../store/form/formSlice';
+```
+
+to:
+
+```typescript
+import { setSubmitted, updateCompanyInfo, setCompanyNameFromUrl } from '../store/form/formSlice';
+```
+
+Add the URL param import after the existing imports (after line 24):
+
+```typescript
+import { getCompanyNameFromUrl } from '../utils/urlParams';
+```
+
+- [ ] **Step 2: Add the useEffect for URL param reading**
+
+In `src/components/MultiStepForm.tsx`, inside `MultiStepFormContent`, add a `useEffect` right after the existing `useEffect` for `isSubmitted` redirect (after line 55):
+
+```typescript
+  useEffect(() => {
+    const companyNameFromUrl = getCompanyNameFromUrl();
+    if (!companyNameFromUrl) return;
+
+    if (!formData.formData.companyInfo.name) {
+      dispatch(updateCompanyInfo({ name: companyNameFromUrl, dba: companyNameFromUrl, legalBusinessName: companyNameFromUrl }));
+    }
+    dispatch(setCompanyNameFromUrl(true));
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/MultiStepForm.tsx
+git commit -m "feat(form): read companyName from URL and persist to Redux on mount (#44)"
+```
+
+---
+
+### Task 4: Add `disabled` prop support to `TextField` component
+
+**Files:**
+- Modify: `src/components/customComponents/TextField.tsx:3,12`
+
+The `TextField` component currently does not accept a `disabled` prop. We need to add it before `CompanyInfo` can use it.
+
+- [ ] **Step 1: Add `disabled` to the props interface and pass to `<input>`**
+
+In `src/components/customComponents/TextField.tsx`, change the component signature on line 3 from:
+
+```typescript
+const TextField = ({ label, name, value, onChange, error, onBlur, onFocus, type, id, placeholder, required }: { label: string, name: string, value: string, onChange: (e: React.ChangeEvent<HTMLInputElement>) => void, error: string, onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void, onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void, type: string, id?: string, placeholder?: string, required?: boolean }) => {
+```
+
+to:
+
+```typescript
+const TextField = ({ label, name, value, onChange, error, onBlur, onFocus, type, id, placeholder, required, disabled }: { label: string, name: string, value: string, onChange: (e: React.ChangeEvent<HTMLInputElement>) => void, error: string, onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void, onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void, type: string, id?: string, placeholder?: string, required?: boolean, disabled?: boolean }) => {
+```
+
+Then add the `disabled` attribute and a conditional style to the `<input>` element. Change the `<input>` (lines 12-28) from:
+
+```tsx
+      <input 
+        autoComplete="on" 
+        type={type} 
+        id={inputId} 
+        value={value} 
+        name={name} 
+        className={`w-full px-4 py-2 text-sm text-gray-900 rounded-3xl border focus:outline-none  focus:ring-purple-400 ${
+          hasFieldError 
+            ? 'border-gray-300 focus:border-red-500' 
+            : 'border-gray-300 focus:border-purple-400'
+        }`} 
+        placeholder={placeholder || ''} 
+        required={required}
+        onChange={onChange} 
+        onBlur={onBlur} 
+        onFocus={onFocus} 
+        title='Please enter your information here' 
+      />
+```
+
+to:
+
+```tsx
+      <input 
+        autoComplete="on" 
+        type={type} 
+        id={inputId} 
+        value={value} 
+        name={name} 
+        className={`w-full px-4 py-2 text-sm text-gray-900 rounded-3xl border focus:outline-none  focus:ring-purple-400 ${
+          hasFieldError 
+            ? 'border-gray-300 focus:border-red-500' 
+            : 'border-gray-300 focus:border-purple-400'
+        } ${disabled ? 'bg-gray-100 cursor-not-allowed opacity-75' : ''}`} 
+        placeholder={placeholder || ''} 
+        required={required}
+        disabled={disabled}
+        onChange={onChange} 
+        onBlur={onBlur} 
+        onFocus={onFocus} 
+        title='Please enter your information here' 
+      />
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/customComponents/TextField.tsx
+git commit -m "feat(ui): add disabled prop to TextField component (#44)"
+```
+
+---
+
+### Task 5: Lock Company Name field in `CompanyInfo` when from URL
+
+**Files:**
+- Modify: `src/components/step1/CompanyInfo.tsx:2-4,22-39,50`
+
+- [ ] **Step 1: Add Redux selector for `companyNameFromUrl`**
+
+In `src/components/step1/CompanyInfo.tsx`, add the selector inside the component (after line 23):
+
+```typescript
+  const companyNameLocked = useSelector((state: RootState) => state.form.companyNameFromUrl);
+```
+
+- [ ] **Step 2: Guard `handleChange` to skip dispatch when locked**
+
+In `src/components/step1/CompanyInfo.tsx`, change the `handleChange` function (lines 28-39) from:
+
+```typescript
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    if(name === "name"){
+      dispatch(updateCompanyInfo({ name: value, dba: value, legalBusinessName: value }));
+      setFieldError('name', null);
+    } else if (name === "role"){
+      dispatch(updatePersonalInfo({ personalInfo: { ...personalInfo, role: value } }));
+      setFieldError( name, null);
+    } else {
+      dispatch(updateCompanyInfo({ [name]: value }));
+      setFieldError(name, null);
+    }
+  };
+```
+
+to:
+
+```typescript
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    if(name === "name"){
+      if (companyNameLocked) return;
+      dispatch(updateCompanyInfo({ name: value, dba: value, legalBusinessName: value }));
+      setFieldError('name', null);
+    } else if (name === "role"){
+      dispatch(updatePersonalInfo({ personalInfo: { ...personalInfo, role: value } }));
+      setFieldError( name, null);
+    } else {
+      dispatch(updateCompanyInfo({ [name]: value }));
+      setFieldError(name, null);
+    }
+  };
+```
+
+- [ ] **Step 3: Make the Company Name field disabled and add helper text**
+
+In `src/components/step1/CompanyInfo.tsx`, change the Company Name TextField (line 50) from:
+
+```tsx
+      <TextField type="text" label="Company Name" name="name" value={companyInfo.name} onChange={handleChange} error='' onBlur={()=>{}} required />
+```
+
+to:
+
+```tsx
+      <TextField type="text" label="Company Name" name="name" value={companyInfo.name} onChange={handleChange} error='' onBlur={()=>{}} required disabled={companyNameLocked} />
+      {companyNameLocked && (
+        <p className="text-xs text-gray-500 -mt-3 mb-3 px-2">Company name set from your invitation link</p>
+      )}
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit 2>&1 | head -20`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/step1/CompanyInfo.tsx
+git commit -m "feat(form): lock Company Name field when set from URL param (#44)"
+```
+
+---
+
+### Task 6: Write unit test for `companyNameFromUrl` reducer
+
+**Files:**
+- Create: `src/store/form/formSlice.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `src/store/form/formSlice.test.ts`:
+
+```typescript
+import { describe, expect, it } from '@jest/globals';
+import { configureStore } from '@reduxjs/toolkit';
+import formReducer, {
+  setCompanyNameFromUrl,
+  updateCompanyInfo,
+} from './formSlice';
+
+const createTestStore = () =>
+  configureStore({ reducer: { form: formReducer } });
+
+describe('setCompanyNameFromUrl', () => {
+  it('sets flag to true', () => {
+    const store = createTestStore();
+    store.dispatch(setCompanyNameFromUrl(true));
+    expect(store.getState().form.companyNameFromUrl).toBe(true);
+  });
+
+  it('defaults to false', () => {
+    const store = createTestStore();
+    expect(store.getState().form.companyNameFromUrl).toBe(false);
+  });
+
+  it('can be toggled back to false', () => {
+    const store = createTestStore();
+    store.dispatch(setCompanyNameFromUrl(true));
+    store.dispatch(setCompanyNameFromUrl(false));
+    expect(store.getState().form.companyNameFromUrl).toBe(false);
+  });
+});
+
+describe('companyName URL flow', () => {
+  it('updateCompanyInfo sets name, dba, and legalBusinessName together', () => {
+    const store = createTestStore();
+    store.dispatch(updateCompanyInfo({ name: 'TestCo', dba: 'TestCo', legalBusinessName: 'TestCo' }));
+    const { companyInfo } = store.getState().form.formData;
+    expect(companyInfo.name).toBe('TestCo');
+    expect(companyInfo.dba).toBe('TestCo');
+    expect(companyInfo.legalBusinessName).toBe('TestCo');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `npx react-scripts test --watchAll=false --testPathPattern='src/store/form/formSlice.test.ts' 2>&1 | tail -20`
+Expected: All 4 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/store/form/formSlice.test.ts
+git commit -m "test(store): add unit tests for companyNameFromUrl reducer (#44)"
+```
+
+---
+
+### Task 7: Manual verification in browser
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `npm start`
+
+- [ ] **Step 2: Test with companyName in URL**
+
+Navigate to `http://localhost:3000/form?companyName=TestCo`
+- Verify: Password screen appears
+- Enter the password, click "Access Form"
+- Verify: URL after login is `/form?companyName=TestCo` (params preserved)
+- Verify: Company Name field shows "TestCo" and is disabled (grayed out)
+- Verify: Helper text "Company name set from your invitation link" appears below the field
+- Navigate to Step 3 and verify DBA and Legal Business Name are pre-filled with "TestCo" but editable
+
+- [ ] **Step 3: Test without companyName in URL**
+
+Navigate to `http://localhost:3000/form`
+- Verify: No password screen (direct access)
+- Verify: Company Name field is empty and editable
+- Verify: No helper text below the field
+
+- [ ] **Step 4: Test persistence on refresh**
+
+After logging in with `?companyName=TestCo`:
+- Refresh the page
+- Verify: Company Name field is still "TestCo" and still disabled (flag persisted in localStorage)

--- a/docs/superpowers/specs/2026-05-28-persist-companyname-url-param-design.md
+++ b/docs/superpowers/specs/2026-05-28-persist-companyname-url-param-design.md
@@ -1,0 +1,75 @@
+# Persist companyName from URL Query Param (Read-Only)
+
+**Issue:** [#44](https://github.com/soundcheck-capital/origination-form/issues/44)
+**Date:** 2026-05-28
+
+## Problem
+
+When a client accesses the form via `?companyName=AcmeCorp`, the company name is used for password verification but lost after `PasswordProtection` navigates to `/form` (without query params). The user can then type a different company name, creating inconsistency.
+
+## Solution
+
+Approach A: Redux flag + useEffect in MultiStepForm.
+
+### 1. Redux State Changes
+
+Add `companyNameFromUrl: boolean` to `FormState`.
+
+**formTypes.ts** — Add field to `FormState` interface (top-level, alongside `isSubmitted`).
+
+**initialFormState.ts** — Set `companyNameFromUrl: false` in initial state.
+
+**formSlice.ts** — New reducer `setCompanyNameFromUrl` that sets the boolean flag and persists to localStorage. Export the action. The flag is hydrated by `hydrateFormState` and `loadFromLocalStorage` so it survives page refresh.
+
+### 2. URL Param Reading (MultiStepForm.tsx)
+
+Add a `useEffect` (runs once on mount) in `MultiStepFormContent`:
+
+- Call `getCompanyNameFromUrl()` (already exists in `src/utils/urlParams.ts`)
+- If non-empty AND `companyInfo.name` is empty: dispatch `updateCompanyInfo({ name, dba, legalBusinessName })` + `setCompanyNameFromUrl(true)`
+- If non-empty AND `companyInfo.name` already set (e.g. from localStorage): dispatch only `setCompanyNameFromUrl(true)`
+- If empty: do nothing
+
+### 3. Preserve Query Params After Password (PasswordProtection.tsx)
+
+Change line 58 from:
+```
+navigate('/form');
+```
+to:
+```
+navigate('/form' + window.location.search);
+```
+
+This preserves `?companyName=...` (and any other params) through the password flow. `RootRedirect` in `index.tsx` already preserves params for the `/` → `/form` redirect.
+
+### 4. Read-Only Field (CompanyInfo.tsx)
+
+- Read `companyNameFromUrl` from Redux state
+- When `true`, render the Company Name `TextField` with `disabled={true}`
+- Show helper text below the field: "Company name set from your invitation link"
+- Guard `handleChange`: if `name === "name"` and locked, skip the dispatch
+
+### 5. Lock Scope
+
+Only the "Company Name" field in Step 1 is locked. DBA and Legal Business Name (Step 3) are pre-filled from the URL value but remain editable.
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `src/store/form/formTypes.ts` | Add `companyNameFromUrl: boolean` to `FormState` |
+| `src/store/form/initialFormState.ts` | Add `companyNameFromUrl: false` |
+| `src/store/form/formSlice.ts` | New `setCompanyNameFromUrl` reducer + export |
+| `src/components/MultiStepForm.tsx` | useEffect to read URL param on mount |
+| `src/components/PasswordProtection.tsx` | Preserve query params in navigate call |
+| `src/components/step1/CompanyInfo.tsx` | Disabled field + helper text when locked |
+
+## Testing
+
+- Visit with `?companyName=TestCo` → field pre-filled and read-only
+- Visit without query param → field editable as before
+- Password screen still works with companyName in URL
+- Refresh after password → field still locked (flag in localStorage)
+- Plaid exchange and form submit send the correct (locked) companyName
+- DBA / Legal Business Name remain editable in Step 3

--- a/env.example
+++ b/env.example
@@ -17,3 +17,8 @@ REACT_APP_CHECK_PASSWORD_CUSTOMER_LINK_WEBHOOK=
 REACT_APP_PLAID_ENV=sandbox
 REACT_APP_PLAID_LINK_TOKEN_URL=
 REACT_APP_PLAID_WEBHOOK_URL=
+
+# E2E tests – custom link path (password-protected company link)
+# Set these to run tests/custom-link-path.spec.ts against a real HubSpot company
+E2E_COMPANY_NAME=
+E2E_COMPANY_PASSWORD=

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eject": "react-scripts eject",
     "test": "react-scripts test --watchAll=false",
     "test:e2e:prod": "playwright test tests/prod-form-critical-path.spec.ts",
+    "test:e2e:custom": "playwright test tests/custom-link-path.spec.ts",
     "test:e2e:plaid": "playwright test tests/plaid-connection.spec.ts",
     "test:e2e": "playwright test"
   },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,12 @@
       "last 1 safari version"
     ]
   },
+  "jest": {
+    "transformIgnorePatterns": [
+      "[/\\\\]node_modules[/\\\\](?!axios/).+\\.(js|jsx|mjs|cjs|ts|tsx)$",
+      "^.+\\.module\\.(css|sass|scss)$"
+    ]
+  },
   "devDependencies": {
     "@playwright/test": "^1.55.0",
     "@types/react": "^19.1.9",

--- a/src/components/MultiStepForm.tsx
+++ b/src/components/MultiStepForm.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { RootState, AppDispatch } from '../store';
-import {   setSubmitted } from '../store/form/formSlice';
+import { setSubmitted, updateCompanyInfo, setCompanyNameFromUrl } from '../store/form/formSlice';
 import { DiligenceFilesProvider } from '../contexts/DiligenceFilesContext';
 import { ValidationProvider, useValidation } from '../contexts/ValidationContext';
 import { useFileUpload } from '../hooks/useFileUpload';
@@ -22,6 +22,7 @@ import '../utils/debugUtils';
 import { getTicketingCoFromUrl, getTicketingPartnerLogo, isValidTicketingPartner } from '../utils/ticketingPartnerUtils';
 import { logCriticalEvent } from '../utils/criticalLogging';
 import { buildUnderwritingWebhookCompanyFields } from '../utils/underwritingFields';
+import { getCompanyNameFromUrl } from '../utils/urlParams';
 
 const MultiStepFormContent: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
@@ -53,6 +54,16 @@ const MultiStepFormContent: React.FC = () => {
       navigate('/submit-success');
     }
   }, [isSubmitted, navigate]);
+
+  useEffect(() => {
+    const companyNameFromUrl = getCompanyNameFromUrl();
+    if (!companyNameFromUrl) return;
+
+    if (!formData.formData.companyInfo.name) {
+      dispatch(updateCompanyInfo({ name: companyNameFromUrl, dba: companyNameFromUrl, legalBusinessName: companyNameFromUrl }));
+    }
+    dispatch(setCompanyNameFromUrl(true));
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSubmit = async () => {
     if (submitInFlightRef.current || isSubmitted) {

--- a/src/components/PasswordProtection.tsx
+++ b/src/components/PasswordProtection.tsx
@@ -55,7 +55,7 @@ const PasswordProtection: React.FC = () => {
 
       if (isValid) {
         localStorage.setItem('formAuthenticated', 'true');
-        navigate('/form');
+        navigate('/form' + window.location.search);
       } else {
         setError('Incorrect password');
       }

--- a/src/components/customComponents/TextField.tsx
+++ b/src/components/customComponents/TextField.tsx
@@ -1,6 +1,6 @@
 import { useValidation } from '../../contexts/ValidationContext';
 
-const TextField = ({ label, name, value, onChange, error, onBlur, onFocus, type, id, placeholder, required }: { label: string, name: string, value: string, onChange: (e: React.ChangeEvent<HTMLInputElement>) => void, error: string, onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void, onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void, type: string, id?: string, placeholder?: string, required?: boolean }) => {
+const TextField = ({ label, name, value, onChange, error, onBlur, onFocus, type, id, placeholder, required, disabled }: { label: string, name: string, value: string, onChange: (e: React.ChangeEvent<HTMLInputElement>) => void, error: string, onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void, onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void, type: string, id?: string, placeholder?: string, required?: boolean, disabled?: boolean }) => {
   const inputId = id || name.replace(/\s+/g, '_').toLowerCase();
   const { hasError, getFieldError } = useValidation();
   const hasFieldError = hasError(name);
@@ -16,12 +16,13 @@ const TextField = ({ label, name, value, onChange, error, onBlur, onFocus, type,
         value={value} 
         name={name} 
         className={`w-full px-4 py-2 text-sm text-gray-900 rounded-3xl border focus:outline-none  focus:ring-purple-400 ${
-          hasFieldError 
-            ? 'border-gray-300 focus:border-red-500' 
+          hasFieldError
+            ? 'border-gray-300 focus:border-red-500'
             : 'border-gray-300 focus:border-purple-400'
-        }`} 
-        placeholder={placeholder || ''} 
+        } ${disabled ? 'bg-gray-100 cursor-not-allowed opacity-75' : ''}`}
+        placeholder={placeholder || ''}
         required={required}
+        disabled={disabled}
         onChange={onChange} 
         onBlur={onBlur} 
         onFocus={onFocus} 

--- a/src/components/step1/CompanyInfo.tsx
+++ b/src/components/step1/CompanyInfo.tsx
@@ -22,12 +22,13 @@ const CompanyInfo: React.FC = () => {
   const companyInfo = useSelector((state: RootState) => state.form.formData.companyInfo);
   const personalInfo = useSelector((state: RootState) => state.form.formData.personalInfo);
   const { setFieldError } = useValidation();
- 
+  const companyNameLocked = useSelector((state: RootState) => state.form.companyNameFromUrl);
 
-  
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
     if(name === "name"){
+      if (companyNameLocked) return;
       dispatch(updateCompanyInfo({ name: value, dba: value, legalBusinessName: value }));
       setFieldError('name', null);
     } else if (name === "role"){
@@ -47,7 +48,10 @@ const CompanyInfo: React.FC = () => {
     <div className="flex flex-col justify-center w-full animate-fade-in-right duration-1000">
       <StepTitle title="Company" />
 
-      <TextField type="text" label="Company Name" name="name" value={companyInfo.name} onChange={handleChange} error='' onBlur={()=>{}} required />
+      <TextField type="text" label="Company Name" name="name" value={companyInfo.name} onChange={handleChange} error='' onBlur={()=>{}} required disabled={companyNameLocked} />
+      {companyNameLocked && (
+        <p className="text-xs text-gray-500 -mt-3 mb-3 px-2">Company name set from your invitation link</p>
+      )}
       <TextField type="text" label="Your Role" name="role" value={personalInfo.role} onChange={handleChange} error='' onBlur={()=>{}} required />
 
       <DropdownField label="Company Type" name="clientType" value={companyInfo.clientType} onChange={handleChange} error='' onBlur={()=>{}} options={clientType} required />

--- a/src/store/form/formSlice.test.ts
+++ b/src/store/form/formSlice.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { configureStore } from '@reduxjs/toolkit';
+
+jest.mock('axios');
+import formReducer, {
+  setCompanyNameFromUrl,
+  updateCompanyInfo,
+} from './formSlice';
+
+const createTestStore = () =>
+  configureStore({ reducer: { form: formReducer } });
+
+describe('setCompanyNameFromUrl', () => {
+  it('sets flag to true', () => {
+    const store = createTestStore();
+    store.dispatch(setCompanyNameFromUrl(true));
+    expect(store.getState().form.companyNameFromUrl).toBe(true);
+  });
+
+  it('defaults to false', () => {
+    const store = createTestStore();
+    expect(store.getState().form.companyNameFromUrl).toBe(false);
+  });
+
+  it('can be toggled back to false', () => {
+    const store = createTestStore();
+    store.dispatch(setCompanyNameFromUrl(true));
+    store.dispatch(setCompanyNameFromUrl(false));
+    expect(store.getState().form.companyNameFromUrl).toBe(false);
+  });
+});
+
+describe('companyName URL flow', () => {
+  it('updateCompanyInfo sets name, dba, and legalBusinessName together', () => {
+    const store = createTestStore();
+    store.dispatch(updateCompanyInfo({ name: 'TestCo', dba: 'TestCo', legalBusinessName: 'TestCo' }));
+    const { companyInfo } = store.getState().form.formData;
+    expect(companyInfo.name).toBe('TestCo');
+    expect(companyInfo.dba).toBe('TestCo');
+    expect(companyInfo.legalBusinessName).toBe('TestCo');
+  });
+});

--- a/src/store/form/formSlice.ts
+++ b/src/store/form/formSlice.ts
@@ -159,7 +159,11 @@ const formSlice = createSlice({
     resetSubmitted: (state) => {
       state.isSubmitted = false;
       localStorage.removeItem('soundcheckFormData');
-    }
+    },
+    setCompanyNameFromUrl: (state, action: PayloadAction<boolean>) => {
+      state.companyNameFromUrl = action.payload;
+      saveToLocalStorage(state);
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -186,20 +190,21 @@ const formSlice = createSlice({
   }
 });
 
-export const { 
-  setCurrentStep, 
-  updatePersonalInfo, 
-  updateCompanyInfo, 
-  updateTicketingInfo, 
-  updateVolumeInfo, 
-  updateFundsInfo, 
-  updateOwnershipInfo, 
+export const {
+  setCurrentStep,
+  updatePersonalInfo,
+  updateCompanyInfo,
+  updateTicketingInfo,
+  updateVolumeInfo,
+  updateFundsInfo,
+  updateOwnershipInfo,
   updateFinancesInfo,
   updateBankInfo,
   updateDiligenceInfo,
   loadSavedApplication,
   clearFormData,
   setSubmitted,
-  resetSubmitted
+  resetSubmitted,
+  setCompanyNameFromUrl
 } = formSlice.actions;
 export default formSlice.reducer;

--- a/src/store/form/formTypes.ts
+++ b/src/store/form/formTypes.ts
@@ -33,6 +33,7 @@ export interface Address {
     email: string;
     emailError: string;
     isSubmitted: boolean;
+    companyNameFromUrl: boolean;
     formData: {
       personalInfo: {
         email: string;

--- a/src/store/form/initialFormState.ts
+++ b/src/store/form/initialFormState.ts
@@ -5,6 +5,7 @@ export const initialState: FormState = {
   email: '',
   emailError: '',
   isSubmitted: false,
+  companyNameFromUrl: false,
   formData: {
     personalInfo: { email: '', firstname: '', lastname: '', phone: '', role: '' },
     companyInfo: {

--- a/tests/custom-link-path.spec.ts
+++ b/tests/custom-link-path.spec.ts
@@ -1,0 +1,229 @@
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+/** All upload selectors that must be filled in step 5. */
+const REQUIRED_UPLOAD_SELECTORS = [
+  "#file-upload-ticketingCompanyReport",
+  "#file-upload-futureEventSchedule",
+  "#file-upload-venueAgreements",
+  "#file-upload-financialsYtdPL",
+  "#file-upload-financialsYtdBS",
+  "#file-upload-financialsYear1PL",
+  "#file-upload-financialsYear1BS",
+  "#file-upload-financialsYear2PL",
+  "#file-upload-financialsYear2BS",
+  "#file-upload-incorporationCertificate",
+] as const;
+
+// ─── custom link happy path ─────────────────────────────────────────────────
+//
+// True E2E for the password-protected custom company link flow.
+// A client accesses the form via ?companyName=..., enters a real password
+// verified by the Make.com → HubSpot webhook, then fills the form with the
+// Company Name field locked (read-only).
+//
+// What's real:  password verification, link-token, file uploads, form submission
+// What's mocked: Plaid exchange only (needs iframe-generated public_token)
+//
+// Requires env vars: E2E_COMPANY_NAME, E2E_COMPANY_PASSWORD
+
+test("custom link happy path – password + locked company name", async ({ page }) => {
+  const companyName = process.env.E2E_COMPANY_NAME;
+  const companyPassword = process.env.E2E_COMPANY_PASSWORD;
+
+  if (!companyName || !companyPassword) {
+    test.skip(!companyName || !companyPassword, "E2E_COMPANY_NAME and E2E_COMPANY_PASSWORD required");
+    return;
+  }
+
+  const now = Date.now();
+  const fixturePath = path.resolve("tests/fixtures/e2e-upload.csv");
+
+  // Bypass Plaid Link UI (third-party iframe)
+  await page.addInitScript(() => {
+    (window as any).__PLAID_TEST_MODE__ = true;
+  });
+
+  // Mock only the Plaid exchange webhook
+  const exchangeWebhookUrl = process.env.REACT_APP_PLAID_WEBHOOK_URL || "";
+  if (exchangeWebhookUrl) {
+    const exchangePath = new URL(exchangeWebhookUrl).pathname;
+    await page.route(`**${exchangePath}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          institution: "Chase",
+          account_mask: "1234",
+          account_name: "Checking",
+        }),
+      });
+    });
+  }
+
+  const failedCriticalRequests: string[] = [];
+  const badCriticalResponses: Array<{ url: string; status: number }> = [];
+
+  const isCriticalUrl = (url: string) =>
+    /(make\.com|\/applications\/|webhook|upload)/i.test(url);
+
+  page.on("requestfailed", (request) => {
+    if (isCriticalUrl(request.url())) {
+      failedCriticalRequests.push(
+        `${request.method()} ${request.url()} :: ${request.failure()?.errorText ?? "failed"}`
+      );
+    }
+  });
+
+  page.on("response", (response) => {
+    const url = response.url();
+    const status = response.status();
+    if (response.request().method() === "POST" && isCriticalUrl(url) && status >= 400) {
+      badCriticalResponses.push({ url, status });
+    }
+  });
+
+  // ── Password screen ──────────────────────────────────────────────────────
+
+  await page.goto(`/form?companyName=${encodeURIComponent(companyName)}`, {
+    waitUntil: "domcontentloaded",
+  });
+
+  // Verify password screen is shown
+  await expect(page.getByRole("heading", { name: "Access Required" })).toBeVisible();
+
+  // Enter password and submit (real call to Make.com → HubSpot)
+  await page.locator('input[name="password"]').fill(companyPassword);
+  await page.getByRole("button", { name: "Access Form" }).click();
+
+  // Wait for navigation after password validation
+  await expect(page.getByRole("heading", { name: "Tell us about your business" })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // Verify query params are preserved in URL after password
+  expect(page.url()).toContain(`companyName=${encodeURIComponent(companyName)}`);
+
+  // ── Step 1 — Company Name locked ─────────────────────────────────────────
+
+  // Verify Company Name field is disabled and pre-filled
+  const companyNameInput = page.locator('input[name="name"]');
+  await expect(companyNameInput).toBeDisabled();
+  await expect(companyNameInput).toHaveValue(companyName);
+
+  // Verify helper text
+  await expect(page.getByText("Company name set from your invitation link")).toBeVisible();
+
+  // Fill remaining required fields (Company Name is already set)
+  await page.locator('input[name="firstname"]').fill("E2E");
+  await page.locator('input[name="lastname"]').fill("CustomLink");
+  await page.locator('input[name="email"]').fill("e2e-custom@example.com");
+  await page.locator('input[name="phone"]').fill("4155552672");
+  await page.locator('input[name="role"]').fill("Owner");
+  await page.locator('select[name="clientType"]').selectOption("Promoter");
+  await page.locator('select[name="yearsInBusiness"]').selectOption("2-5 years");
+  await page.locator('input[name="socials"]').fill("https://example.com");
+  await page.locator('select[name="memberOf"]').selectOption("None");
+
+  await page.locator('input[name="nextYearEvents"]').fill("10");
+  await page.locator('input[name="nextYearSales"]').fill("200000");
+  await page.locator('select[name="paymentProcessing"]').selectOption("Ticketing Co");
+  await page.locator('select[name="currentPartner"]').selectOption("Eventbrite");
+  await page.locator('select[name="settlementPayout"]').selectOption("Weekly");
+  await page.locator('select[name="paymentProcessor"]').selectOption("Stripe");
+  await page.locator('select[name="accountingSystem"]').selectOption("QuickBooks");
+
+  await page.getByRole("button", { name: "Next" }).click();
+
+  // ── Step 2 — Get funding ─────────────────────────────────────────────────
+
+  await expect(page.locator('select[name="timingOfFunding"]')).toBeVisible();
+  await page.locator('select[name="timingOfFunding"]').selectOption("In the next month");
+  await page.locator('select[name="useOfProceeds"]').selectOption("General Working Capital Needs");
+
+  await page.getByRole("button", { name: "Next" }).click();
+
+  // ── Step 3 — Business & Ownership ────────────────────────────────────────
+  // DBA and Legal Business Name should be pre-filled but editable
+
+  await expect(page.locator('input[name="legalEntityName"]')).toBeVisible();
+
+  const dbaInput = page.locator('input[name="dba"]');
+  await expect(dbaInput).toHaveValue(companyName);
+  await expect(dbaInput).toBeEnabled(); // DBA stays editable
+
+  await page.locator('input[name="legalEntityName"]').fill(`${companyName} LLC`);
+  await page.locator('select[name="businessType"]').selectOption("Limited Liability Company (LLC)");
+  await page.locator('select[name="stateOfIncorporation"]').selectOption("CA");
+  await page.locator('input[name="companyAddressDisplay"]').fill(
+    "123 Market St, San Francisco, CA 94105, USA"
+  );
+  await page.locator('input[name="ein"]').fill("12-3456789");
+  await page.locator('input[name="owner0Name"]').fill("Jane Owner");
+  await page.locator('input[name="owner0Percentage"]').fill("100");
+  await page.locator('input[name="owner0Address"]').fill(
+    "123 Main St, San Francisco, CA 94105, USA"
+  );
+  await page.locator('input[name="owner0BirthDate"]').fill("1988-01-01");
+  await page.locator('textarea[name="industryReferences"]').fill(`Reference for ${companyName}`);
+  await page.locator('textarea[name="additionalComments"]').fill(
+    `Automated E2E custom link run ${now}`
+  );
+
+  await page.getByRole("button", { name: "Next" }).click();
+
+  // ── Step 4 — Bank Connection ─────────────────────────────────────────────
+
+  await expect(page.getByRole("heading", { name: "Bank Connection" })).toBeVisible();
+  await page.getByRole("button", { name: "Connect your bank account" }).click();
+  await expect(page.getByTestId("plaid-connected-card")).toBeVisible();
+  await page.getByRole("button", { name: "Next" }).click();
+
+  // ── Step 5 — Diligence Files ─────────────────────────────────────────────
+
+  await expect(page.locator("#file-upload-ticketingCompanyReport")).toBeVisible();
+
+  const waitForUploadPost = () =>
+    page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        response.url().includes("hook.us1.make.com"),
+      { timeout: 30_000 }
+    );
+
+  const uploadField = async (selector: string) => {
+    const pending = waitForUploadPost();
+    await page.locator(selector).setInputFiles(fixturePath);
+    const result = await pending;
+    expect(result.status()).toBeLessThan(400);
+  };
+
+  for (const selector of REQUIRED_UPLOAD_SELECTORS) {
+    await uploadField(selector);
+  }
+
+  await expect(page.getByText("e2e-upload.csv").first()).toBeVisible();
+
+  const nextButton = page.getByRole("button", { name: "Next" });
+  await expect(nextButton).toBeEnabled();
+  await nextButton.click();
+
+  // ── Step 6 — Review & Submit ─────────────────────────────────────────────
+
+  const submitButton = page.getByRole("button", { name: "Submit" });
+  await expect(submitButton).toBeVisible();
+  await expect(submitButton).toBeEnabled();
+
+  await submitButton.click();
+  await expect(submitButton).toBeDisabled();
+
+  await page.waitForURL("**/submit-success", { timeout: 20_000 });
+  await expect(page).toHaveURL(/\/submit-success$/);
+  await expect(page.getByText("Application Submitted Successfully")).toBeVisible();
+
+  // No critical HTTP errors throughout the flow
+  expect(failedCriticalRequests, failedCriticalRequests.join("\n")).toEqual([]);
+  expect(badCriticalResponses, JSON.stringify(badCriticalResponses, null, 2)).toEqual([]);
+});

--- a/tests/prod-form-critical-path.spec.ts
+++ b/tests/prod-form-critical-path.spec.ts
@@ -32,8 +32,9 @@ const REQUIRED_UPLOAD_SELECTORS = [
 // What's mocked: exchange only (needs iframe-generated public_token)
 
 test("generic happy path", async ({ page }) => {
-  const now = Date.now();
-  const tag = `GENERIC_E2E_${now}`;
+  const now = new Date();
+  const monthYear = `${String(now.getMonth() + 1).padStart(2, "0")}-${now.getFullYear()}`;
+  const tag = `GENERIC E2E - ${monthYear}`;
   const email = "e2e@example.com";
   const fixturePath = path.resolve("tests/fixtures/e2e-upload.csv");
 

--- a/tests/prod-form-critical-path.spec.ts
+++ b/tests/prod-form-critical-path.spec.ts
@@ -33,7 +33,7 @@ const REQUIRED_UPLOAD_SELECTORS = [
 
 test("generic happy path", async ({ page }) => {
   const now = Date.now();
-  const tag = `E2E_PROD_${now}`;
+  const tag = `GENERIC_E2E_${now}`;
   const email = "e2e@example.com";
   const fixturePath = path.resolve("tests/fixtures/e2e-upload.csv");
 


### PR DESCRIPTION
## Summary

- **Persist companyName from URL query param** into Redux state when a client accesses the form via `?companyName=AcmeCorp`
- **Lock the Company Name field** as read-only (disabled) when pre-filled from URL, with helper text "Company name set from your invitation link"
- **Preserve query params** through the password validation flow (previously `navigate('/form')` dropped them)
- DBA and Legal Business Name remain editable in Step 3

Closes #44

## Changes

| File | Change |
|---|---|
| `src/store/form/formTypes.ts` | Add `companyNameFromUrl: boolean` to `FormState` |
| `src/store/form/initialFormState.ts` | Set initial value `false` |
| `src/store/form/formSlice.ts` | New `setCompanyNameFromUrl` reducer |
| `src/components/MultiStepForm.tsx` | `useEffect` reads URL param on mount → Redux |
| `src/components/PasswordProtection.tsx` | `navigate('/form' + window.location.search)` |
| `src/components/customComponents/TextField.tsx` | Add `disabled` prop with styling |
| `src/components/step1/CompanyInfo.tsx` | Disabled field + guard + helper text |
| `src/store/form/formSlice.test.ts` | 4 unit tests for the new reducer |

## Test plan

- [ ] Visit with `?companyName=TestCo` → field is pre-filled and disabled
- [ ] Visit without query param → field is empty and editable
- [ ] Password screen still works, URL params preserved after login
- [ ] Refresh after login → field still locked (persisted in localStorage)
- [ ] Plaid exchange and form submit send the correct company name
- [ ] DBA / Legal Business Name remain editable in Step 3
- [ ] All 31 unit tests pass (27 existing + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)